### PR TITLE
Add wallet balance tracking to load-test command

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -602,6 +602,14 @@ pub struct LoadTestArgs {
     /// Read-only gRPC port for balance queries (requires read-only node)
     #[arg(long = "readonly-port", default_value_t = 40452)]
     pub readonly_port: u16,
+
+    /// Maximum time in seconds to wait for block inclusion
+    #[arg(long = "inclusion-timeout", default_value_t = 120)]
+    pub inclusion_timeout: u64,
+
+    /// Maximum time in seconds to wait for block finalization
+    #[arg(long = "finalization-timeout", default_value_t = 120)]
+    pub finalization_timeout: u64,
 }
 
 /// Arguments for validator-status command


### PR DESCRIPTION
- Add --readonly-port flag (default: 40452) for balance queries
- Display initial sender and recipient wallet balances before tests start
- Print sender wallet balance after each test iteration completes
- Create get_balance_for_address() helper to query any REV address
- Use separate read-only API instance for balance queries to avoid interference with test deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)