### PR TITLE
ci: add build, test, and release workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,375 @@
+name: Build and Test
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - dev
+    tags: "v**"
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  # Build base: version discovery and worktree packing.
+  # Skip release commits on branch pushes — the tag push handles the release build.
+  build_base:
+    name: Build Base
+    runs-on: ubuntu-latest
+    if: >-
+      !startsWith(github.event.head_commit.message, 'chore(release)')
+      || startsWith(github.ref, 'refs/tags/')
+    outputs:
+      VERSION: ${{ env.VERSION }}
+      BRANCH: ${{ env.BRANCH }}
+      IMAGE_TAG: ${{ env.IMAGE_TAG }}
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2025-06-15
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Tool versions
+        shell: bash -ex {0}
+        run: |
+          rustc --version
+          cargo --version
+
+      - name: Initialize Environment
+        shell: bash -exu -o pipefail {0}
+        run: |
+          git fetch origin
+          git fetch origin --tags --force
+
+          # Version from Git repository (tag-commit)
+          VERSION="$(git describe --tags --always)"
+          # Strip tag prefix for clean version string
+          VERSION="${VERSION#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+          # Find related HEAD branch
+          BRANCH=""
+          if [[ $GITHUB_REF =~ ^refs/tags/ ]]; then
+            # For tag pushes, determine release type from tag name
+            # patch .0 = main release, patch > 0 = dev release
+            TAG_NAME="${GITHUB_REF#refs/tags/}"
+            TAG_VERSION="${TAG_NAME#v}"
+            PATCH=$(echo "$TAG_VERSION" | cut -d. -f3)
+            if [ "$PATCH" = "0" ]; then
+              BRANCH="main"
+            else
+              BRANCH="dev"
+            fi
+          elif [[ $GITHUB_REF =~ ^refs/heads/ ]]; then
+            BRANCH=${GITHUB_REF#refs/*/}
+          else
+            BRANCH=$GITHUB_HEAD_REF
+          fi
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+
+          # Determine f1r3node Docker image tag based on branch
+          if [ "$BRANCH" = "main" ]; then
+            echo "IMAGE_TAG=latest" >> $GITHUB_ENV
+          else
+            echo "IMAGE_TAG=dev" >> $GITHUB_ENV
+          fi
+
+      - name: Pack Working Tree
+        shell: bash -ex {0}
+        run: tar -H posix -czf /tmp/rust-client-worktree.tar.gz .
+
+      - name: Save Working Tree
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-client-worktree
+          path: /tmp/rust-client-worktree.tar.gz
+
+  # Build on both architectures. Verifies CLI and library compilation.
+  build:
+    name: Build (${{ matrix.arch }})
+    needs: build_base
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2025-06-15
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Load Working Tree
+        uses: actions/download-artifact@v4
+        with:
+          name: rust-client-worktree
+          path: /tmp
+
+      - name: Restore Working Tree
+        shell: bash -ex {0}
+        run: tar -H posix -xzf /tmp/rust-client-worktree.tar.gz
+
+      - name: Build CLI
+        shell: bash -ex {0}
+        run: cargo build --release
+
+      - name: Build Library (no default features)
+        shell: bash -ex {0}
+        run: cargo build --release --no-default-features
+
+      - name: Upload Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-client-binary-${{ matrix.arch }}
+          path: target/release/node_cli
+
+  # Unit tests (offline — no node required).
+  unit_tests:
+    name: Unit Tests (${{ matrix.arch }})
+    needs: build
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2025-06-15
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Load Working Tree
+        uses: actions/download-artifact@v4
+        with:
+          name: rust-client-worktree
+          path: /tmp
+
+      - name: Restore Working Tree
+        shell: bash -ex {0}
+        run: tar -H posix -xzf /tmp/rust-client-worktree.tar.gz
+
+      - name: Run Unit Tests
+        shell: bash -ex {0}
+        env:
+          RUST_BACKTRACE: "1"
+        run: |
+          mkdir -p /tmp/test-logs
+          cargo test --release 2>&1 | tee /tmp/test-logs/unit-test-output.txt
+          TEST_EXIT_CODE=${PIPESTATUS[0]}
+          exit $TEST_EXIT_CODE
+
+      - name: Upload Test Logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-logs-${{ matrix.arch }}
+          path: /tmp/test-logs/
+          retention-days: 7
+
+  # Smoke tests against standalone f1r3node (Rust and Scala implementations).
+  # Pulls pre-built f1r3node Docker images from Docker Hub.
+  smoke_tests:
+    name: Smoke Tests (${{ matrix.arch.name }}/${{ matrix.node }})
+    needs:
+      - build_base
+      - unit_tests
+    runs-on: ${{ matrix.arch.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - { runner: ubuntu-latest, name: amd64 }
+          - { runner: ubuntu-24.04-arm, name: arm64 }
+        node:
+          - rust
+          - scala
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2025-06-15
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Clone system-integration
+        uses: actions/checkout@v4
+        with:
+          repository: F1R3FLY-io/system-integration
+          ref: main
+          path: system-integration
+
+      - name: Load Working Tree
+        uses: actions/download-artifact@v4
+        with:
+          name: rust-client-worktree
+          path: /tmp
+
+      - name: Restore Working Tree
+        shell: bash -ex {0}
+        run: tar -H posix -xzf /tmp/rust-client-worktree.tar.gz
+
+      - name: Pull f1r3node Docker image
+        shell: bash -ex {0}
+        env:
+          IMAGE_TAG: ${{ needs.build_base.outputs.IMAGE_TAG }}
+        run: |
+          if [ "${{ matrix.node }}" = "rust" ]; then
+            docker pull f1r3flyindustries/f1r3fly-rust-node:${IMAGE_TAG}
+          else
+            docker pull f1r3flyindustries/f1r3fly-scala-node:${IMAGE_TAG}
+          fi
+
+      - name: Start standalone node
+        shell: bash -ex {0}
+        env:
+          IMAGE_TAG: ${{ needs.build_base.outputs.IMAGE_TAG }}
+        run: |
+          cd system-integration/integration-tests
+          if [ "${{ matrix.node }}" = "rust" ]; then
+            F1R3FLY_RUST_IMAGE="f1r3flyindustries/f1r3fly-rust-node:${IMAGE_TAG}" \
+              docker compose -f docker-compose.standalone-rust.yml up -d
+          else
+            F1R3FLY_SCALA_IMAGE="f1r3flyindustries/f1r3fly-scala-node:${IMAGE_TAG}" \
+              docker compose -f docker-compose.standalone-scala.yml up -d
+          fi
+
+      - name: Wait for node healthy
+        shell: bash {0}
+        run: |
+          echo "Waiting for standalone node to become healthy..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:40463/api/status >/dev/null 2>&1; then
+              echo "Node is healthy after $((i * 5))s"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Node failed to become healthy after 300s"
+          docker logs rnode.standalone 2>&1 | tail -50
+          exit 1
+
+      - name: Run Smoke Tests
+        shell: bash -ex {0}
+        run: ./scripts/smoke_test.sh localhost 40462 40463
+
+      - name: Upload Smoke Test Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-logs-${{ matrix.arch.name }}-${{ matrix.node }}
+          path: logs/
+          retention-days: 7
+
+      - name: Capture Docker Logs
+        if: always()
+        shell: bash {0}
+        run: |
+          mkdir -p /tmp/docker-logs
+          docker logs rnode.standalone > /tmp/docker-logs/standalone.log 2>&1 || true
+
+      - name: Upload Docker Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-logs-${{ matrix.arch.name }}-${{ matrix.node }}
+          path: /tmp/docker-logs/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Teardown
+        if: always()
+        shell: bash {0}
+        run: |
+          cd system-integration/integration-tests
+          if [ "${{ matrix.node }}" = "rust" ]; then
+            docker compose -f docker-compose.standalone-rust.yml down -v
+          else
+            docker compose -f docker-compose.standalone-scala.yml down -v
+          fi
+
+  # GitHub Release with compiled binaries and changelog.
+  release_packages:
+    name: Release Packages
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    needs:
+      - smoke_tests
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (for CHANGELOG.md)
+        uses: actions/checkout@v4
+
+      - name: Load amd64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: rust-client-binary-amd64
+          path: /tmp/amd64
+
+      - name: Load arm64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: rust-client-binary-arm64
+          path: /tmp/arm64
+
+      - name: Prepare release artifacts
+        shell: bash -ex {0}
+        run: |
+          mkdir -p /tmp/release
+          cp /tmp/amd64/node_cli /tmp/release/rust-client-linux-amd64
+          cp /tmp/arm64/node_cli /tmp/release/rust-client-linux-arm64
+          chmod +x /tmp/release/rust-client-linux-amd64
+          chmod +x /tmp/release/rust-client-linux-arm64
+
+      - name: Determine release type
+        id: release_type
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          PATCH=$(echo "$TAG" | cut -d. -f3)
+          if [ "$PATCH" = "0" ]; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: /tmp/release/*
+          prerelease: ${{ steps.release_type.outputs.prerelease }}
+          draft: false
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          bodyFile: CHANGELOG.md
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,11 +37,18 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
+      - name: Install protobuf compiler
+        shell: bash -ex {0}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
       - name: Tool versions
         shell: bash -ex {0}
         run: |
           rustc --version
           cargo --version
+          protoc --version
 
       - name: Initialize Environment
         shell: bash -exu -o pipefail {0}
@@ -120,6 +127,12 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
+      - name: Install protobuf compiler
+        shell: bash -ex {0}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
       - name: Load Working Tree
         uses: actions/download-artifact@v4
         with:
@@ -171,6 +184,12 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+
+      - name: Install protobuf compiler
+        shell: bash -ex {0}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
 
       - name: Load Working Tree
         uses: actions/download-artifact@v4
@@ -230,6 +249,12 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+
+      - name: Install protobuf compiler
+        shell: bash -ex {0}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
 
       - name: Clone system-integration
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -102,8 +102,12 @@ jobs:
         include:
           - runner: ubuntu-latest
             arch: amd64
+            rustflags: "-C target-feature=+aes,+sse2"
           - runner: ubuntu-24.04-arm
             arch: arm64
+            rustflags: "-C target-feature=+aes,+neon"
+    env:
+      RUSTFLAGS: ${{ matrix.rustflags }}
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4
@@ -150,8 +154,12 @@ jobs:
         include:
           - runner: ubuntu-latest
             arch: amd64
+            rustflags: "-C target-feature=+aes,+sse2"
           - runner: ubuntu-24.04-arm
             arch: arm64
+            rustflags: "-C target-feature=+aes,+neon"
+    env:
+      RUSTFLAGS: ${{ matrix.rustflags }}
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4
@@ -204,11 +212,13 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - { runner: ubuntu-latest, name: amd64 }
-          - { runner: ubuntu-24.04-arm, name: arm64 }
+          - { runner: ubuntu-latest, name: amd64, rustflags: "-C target-feature=+aes,+sse2" }
+          - { runner: ubuntu-24.04-arm, name: arm64, rustflags: "-C target-feature=+aes,+neon" }
         node:
           - rust
           - scala
+    env:
+      RUSTFLAGS: ${{ matrix.arch.rustflags }}
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+# Auto-release — bumps version on merge to main or dev
+#
+# - main: bumps minor (0.1.0 -> 0.2.0)
+# - dev:  bumps patch (0.1.0 -> 0.1.1)
+#
+# Determines the next version from the latest v* tag, bumps Cargo.toml,
+# generates CHANGELOG.md via git-cliff, commits, and pushes. The tag is
+# created via the GitHub API with a PAT so it triggers the existing CI
+# workflow for testing and package publishing.
+#
+# Commit push uses GITHUB_TOKEN (no workflow triggers).
+# Tag creation uses RELEASE_PAT (triggers on:push:tags workflows).
+
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Bump Version & Tag
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      !startsWith(github.event.head_commit.message, 'chore(release)')
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Force-refresh tags
+        run: git fetch origin --tags --force
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install git-cliff
+        uses: orhun/git-cliff-action@v4
+        with:
+          args: --version
+
+      - name: Determine next version
+        id: version
+        run: |
+          source scripts/version.sh
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          if [ "$BRANCH" = "main" ]; then
+            bump_version minor
+          else
+            bump_version patch
+          fi
+          echo "NEXT_VERSION=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "BRANCH=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "Next version: $NEXT_VERSION (tag: $TAG_NAME) [branch: $BRANCH]"
+
+      - name: Update Cargo.toml version
+        run: |
+          sed -i "0,/^version = \".*\"/s//version = \"${{ steps.version.outputs.NEXT_VERSION }}\"/" Cargo.toml
+
+      - name: Update Cargo.lock
+        run: cargo generate-lockfile
+
+      - name: Generate CHANGELOG
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --tag ${{ steps.version.outputs.TAG_NAME }} -o CHANGELOG.md
+
+      - name: Commit release
+        run: |
+          git add Cargo.toml Cargo.lock CHANGELOG.md
+          git commit -m "chore(release): v${{ steps.version.outputs.NEXT_VERSION }}"
+
+      - name: Push commits (GITHUB_TOKEN — no workflow triggers)
+        run: |
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+          git push origin ${{ steps.version.outputs.BRANCH }}
+
+      - name: Create tag via API (PAT — triggers downstream CI)
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.RELEASE_PAT }}
+          script: |
+            const tagName = '${{ steps.version.outputs.TAG_NAME }}';
+
+            // Get the SHA of the release commit (HEAD after our commits)
+            const { execSync } = require('child_process');
+            const commitSha = execSync('git rev-parse HEAD').toString().trim();
+
+            // Create annotated tag object
+            const tagObject = await github.rest.git.createTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: tagName,
+              message: `Release ${tagName}`,
+              object: commitSha,
+              type: 'commit'
+            });
+
+            // Create tag reference
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${tagName}`,
+              sha: tagObject.data.sha
+            });
+
+            console.log(`Created tag ${tagName} -> ${commitSha}`);

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,46 @@
+# git-cliff configuration for rust-client
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = """# Changelog
+
+All notable changes to the F1r3fly rust-client will be documented in this file.
+This changelog is automatically generated from conventional commits.\n
+"""
+body = """
+{%- if version %}
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{%- else %}
+## [unreleased]
+{%- endif %}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | split(pat="\n") | first | trim }}\
+  {% if commit.breaking %} [**breaking**]{% endif %}\
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^ci", group = "CI" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^Merge", skip = true },
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "v[0-9].*"
+sort_commits = "newest"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Manual release script for rust-client
+#
+# Usage: ./scripts/release.sh [major|minor|patch]
+#   Default bump type: minor
+#
+# This is an escape hatch for when you need a non-minor bump (e.g., major
+# or patch). For normal releases, merging to main triggers the CI
+# workflow which auto-bumps minor.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_DIR"
+
+# Ensure working tree is clean
+git diff --quiet && git diff --cached --quiet || {
+    echo "ERROR: working tree is dirty — commit or stash changes first"
+    exit 1
+}
+
+# Source shared version logic
+source "$SCRIPT_DIR/version.sh"
+bump_version "${1:-minor}"
+
+echo "Current: ${CURRENT_VERSION} -> Next: ${NEXT_VERSION} (${TAG_NAME})"
+echo ""
+
+# Update Cargo.toml version (portable sed for GNU + BSD/macOS)
+sed -i'' -e "0,/^version = \".*\"/s//version = \"${NEXT_VERSION}\"/" Cargo.toml
+echo "Updated Cargo.toml to ${NEXT_VERSION}"
+
+# Update Cargo.lock
+cargo generate-lockfile 2>/dev/null || true
+echo "Updated Cargo.lock"
+
+# Generate CHANGELOG if git-cliff is available
+if command -v git-cliff &>/dev/null; then
+    git-cliff --config cliff.toml --tag "$TAG_NAME" -o CHANGELOG.md
+    echo "Generated CHANGELOG.md"
+else
+    echo "WARNING: git-cliff not found, skipping CHANGELOG generation"
+    echo "Install: cargo install git-cliff"
+fi
+
+# Commit and tag
+git add Cargo.toml Cargo.lock CHANGELOG.md
+git commit -m "chore(release): v${NEXT_VERSION}"
+git tag -a "$TAG_NAME" -m "Release v${NEXT_VERSION}"
+
+echo ""
+echo "Release ${TAG_NAME} created."
+echo ""
+echo "To publish:"
+echo "  git push origin $(git branch --show-current) --follow-tags"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Shared version discovery and bumping logic for rust-client
+#
+# Usage (sourced by other scripts):
+#   source scripts/version.sh
+#   get_current_version    # sets CURRENT_VERSION
+#   bump_version minor     # sets NEXT_VERSION, TAG_NAME
+#
+# Usage (standalone):
+#   ./scripts/version.sh [current|next [major|minor|patch]]
+
+set -euo pipefail
+
+TAG_PREFIX="v"
+TAG_PATTERN="v*"
+
+# Discover the current version from the latest matching tag
+get_current_version() {
+    local latest_tag
+    latest_tag=$(git tag -l "$TAG_PATTERN" --sort=-v:refname | head -1)
+    if [ -z "$latest_tag" ]; then
+        CURRENT_VERSION="0.1.0"
+        return
+    fi
+    CURRENT_VERSION="${latest_tag#$TAG_PREFIX}"
+
+    # Validate semver format
+    if ! [[ "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "ERROR: invalid version format in tag '$latest_tag': $CURRENT_VERSION" >&2
+        exit 1
+    fi
+}
+
+# Bump version based on type (major|minor|patch)
+# Sets NEXT_VERSION and TAG_NAME
+bump_version() {
+    local bump_type="${1:-minor}"
+
+    get_current_version
+
+    local major minor patch
+    major=$(echo "$CURRENT_VERSION" | cut -d. -f1)
+    minor=$(echo "$CURRENT_VERSION" | cut -d. -f2)
+    patch=$(echo "$CURRENT_VERSION" | cut -d. -f3)
+
+    case "$bump_type" in
+        major)
+            major=$((major + 1))
+            minor=0
+            patch=0
+            ;;
+        minor)
+            minor=$((minor + 1))
+            patch=0
+            ;;
+        patch)
+            patch=$((patch + 1))
+            ;;
+        *)
+            echo "ERROR: invalid bump type '$bump_type' (use major|minor|patch)" >&2
+            exit 1
+            ;;
+    esac
+
+    NEXT_VERSION="${major}.${minor}.${patch}"
+    TAG_NAME="${TAG_PREFIX}${NEXT_VERSION}"
+}
+
+# Standalone usage
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    CMD="${1:-current}"
+    case "$CMD" in
+        current)
+            get_current_version
+            echo "$CURRENT_VERSION"
+            ;;
+        next)
+            bump_version "${2:-minor}"
+            echo "$NEXT_VERSION (tag: $TAG_NAME)"
+            ;;
+        *)
+            echo "Usage: $0 [current|next [major|minor|patch]]"
+            exit 1
+            ;;
+    esac
+fi


### PR DESCRIPTION
## Summary

- Add CI pipeline (`build-and-test.yml`) with dual-arch (amd64/arm64) build, unit tests, and smoke tests against both Rust and Scala standalone f1r3node images pulled from Docker Hub
- Add auto-versioning (`release.yml`) that bumps minor on merge to main, patch on merge to dev, using `v{MAJOR}.{MINOR}.{PATCH}` tag convention with git-cliff changelogs
- Add supporting scripts (`version.sh`, `release.sh`) and `cliff.toml` matching the f1r3node-rust versioning pattern

## Test plan

- [ ] Verify `build-and-test.yml` triggers on push to this branch
- [ ] Verify `build_base` job discovers version and packs worktree
- [ ] Verify `build` jobs compile CLI and library on both architectures
- [ ] Verify `unit_tests` pass on both architectures
- [ ] Verify `smoke_tests` pass against standalone Rust node (amd64/arm64)
- [ ] Verify `smoke_tests` pass against standalone Scala node (amd64/arm64)
- [ ] Verify `release.yml` is skipped on this branch (only triggers on main/dev)
- [ ] Verify `RELEASE_PAT` secret is configured in repo settings
- [ ] Verify `scripts/version.sh current` works locally
- [ ] After merge to dev, verify `release.yml` bumps patch and tags correctly

Co-Authored-By: Claude <noreply@anthropic.com>