### PR TITLE
merge: staging into dev (API redesign + native token metadata)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -316,16 +316,19 @@ jobs:
             docker pull f1r3flyindustries/f1r3fly-scala-node:${IMAGE_TAG}
           fi
 
-      - name: Start standalone node
+      - name: Start node
         shell: bash -ex {0}
         env:
           IMAGE_TAG: ${{ needs.build_base.outputs.IMAGE_TAG }}
         run: |
-          cd system-integration/integration-tests
+          cd system-integration
           if [ "${{ matrix.node }}" = "rust" ]; then
+            # Shard: bootstrap + 3 validators + readonly (tests validator vs readonly behavior)
             F1R3FLY_RUST_IMAGE="f1r3flyindustries/f1r3fly-rust-node:${IMAGE_TAG}" \
-              docker compose -f docker-compose.standalone-rust.yml up -d
+              docker compose --env-file .env.node -f compose/f1r3node-rust.yml up -d
           else
+            # Scala: standalone (no shard compose available)
+            cd integration-tests
             F1R3FLY_SCALA_IMAGE="f1r3flyindustries/f1r3fly-scala-node:${IMAGE_TAG}" \
               docker compose -f docker-compose.standalone-scala.yml up -d
           fi
@@ -333,21 +336,52 @@ jobs:
       - name: Wait for node healthy
         shell: bash {0}
         run: |
-          echo "Waiting for standalone node to become healthy..."
-          for i in $(seq 1 60); do
-            if curl -sf http://localhost:40463/api/status >/dev/null 2>&1; then
-              echo "Node is healthy after $((i * 5))s"
-              exit 0
-            fi
-            sleep 5
-          done
-          echo "Node failed to become healthy after 300s"
-          docker logs rnode.standalone 2>&1 | tail -50
-          exit 1
+          if [ "${{ matrix.node }}" = "rust" ]; then
+            # Wait for validator1 to be ready (isReady=true via status API)
+            echo "Waiting for shard to become healthy..."
+            for i in $(seq 1 60); do
+              READY=$(curl -sf http://localhost:40413/api/status 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('isReady',False))" 2>/dev/null || echo "False")
+              if [ "$READY" = "True" ]; then
+                echo "Shard is healthy after $((i * 5))s"
+                exit 0
+              fi
+              sleep 5
+            done
+            echo "Shard failed to become healthy after 300s"
+            docker logs rnode.validator1 2>&1 | tail -50
+            exit 1
+          else
+            echo "Waiting for standalone node to become healthy..."
+            for i in $(seq 1 60); do
+              if curl -sf http://localhost:40463/api/status >/dev/null 2>&1; then
+                echo "Node is healthy after $((i * 5))s"
+                exit 0
+              fi
+              sleep 5
+            done
+            echo "Node failed to become healthy after 300s"
+            docker logs rnode.standalone 2>&1 | tail -50
+            exit 1
+          fi
 
-      - name: Run Smoke Tests
+      - name: Run Smoke Tests (bash)
         shell: bash -ex {0}
-        run: ./scripts/smoke_test.sh localhost 40462 40463
+        run: |
+          if [ "${{ matrix.node }}" = "rust" ]; then
+            # Shard: validator1 gRPC=40412, HTTP=40413, readonly gRPC=40452
+            ./scripts/smoke_test.sh localhost 40412 40413 40452
+          else
+            # Scala standalone: gRPC=40462, HTTP=40463
+            ./scripts/smoke_test.sh localhost 40462 40463
+          fi
+
+      - name: Run Integration Tests (Rust)
+        if: matrix.node == 'rust'
+        shell: bash -ex {0}
+        env:
+          F1R3FLY_HTTP_PORT: "40413"
+          F1R3FLY_OBSERVER_HTTP: "40453"
+        run: cargo test --test smoke --release -- --ignored
 
       - name: Upload Smoke Test Logs
         if: always()
@@ -362,7 +396,13 @@ jobs:
         shell: bash {0}
         run: |
           mkdir -p /tmp/docker-logs
-          docker logs rnode.standalone > /tmp/docker-logs/standalone.log 2>&1 || true
+          if [ "${{ matrix.node }}" = "rust" ]; then
+            for name in bootstrap validator1 validator2 validator3 readonly; do
+              docker logs rnode.${name} > /tmp/docker-logs/${name}.log 2>&1 || true
+            done
+          else
+            docker logs rnode.standalone > /tmp/docker-logs/standalone.log 2>&1 || true
+          fi
 
       - name: Upload Docker Logs
         if: always()
@@ -377,10 +417,11 @@ jobs:
         if: always()
         shell: bash {0}
         run: |
-          cd system-integration/integration-tests
           if [ "${{ matrix.node }}" = "rust" ]; then
-            docker compose -f docker-compose.standalone-rust.yml down -v
+            cd system-integration
+            docker compose --env-file .env.node -f compose/f1r3node-rust.yml down -v
           else
+            cd system-integration/integration-tests
             docker compose -f docker-compose.standalone-scala.yml down -v
           fi
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -321,14 +321,11 @@ jobs:
         env:
           IMAGE_TAG: ${{ needs.build_base.outputs.IMAGE_TAG }}
         run: |
-          cd system-integration
+          cd system-integration/integration-tests
           if [ "${{ matrix.node }}" = "rust" ]; then
-            # Shard: bootstrap + 3 validators + readonly (tests validator vs readonly behavior)
             F1R3FLY_RUST_IMAGE="f1r3flyindustries/f1r3fly-rust-node:${IMAGE_TAG}" \
-              docker compose --env-file .env.node -f compose/f1r3node-rust.yml up -d
+              docker compose -f docker-compose.standalone-rust.yml up -d
           else
-            # Scala: standalone (no shard compose available)
-            cd integration-tests
             F1R3FLY_SCALA_IMAGE="f1r3flyindustries/f1r3fly-scala-node:${IMAGE_TAG}" \
               docker compose -f docker-compose.standalone-scala.yml up -d
           fi
@@ -336,51 +333,28 @@ jobs:
       - name: Wait for node healthy
         shell: bash {0}
         run: |
-          if [ "${{ matrix.node }}" = "rust" ]; then
-            # Wait for validator1 to be ready (isReady=true via status API)
-            echo "Waiting for shard to become healthy..."
-            for i in $(seq 1 60); do
-              READY=$(curl -sf http://localhost:40413/api/status 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('isReady',False))" 2>/dev/null || echo "False")
-              if [ "$READY" = "True" ]; then
-                echo "Shard is healthy after $((i * 5))s"
-                exit 0
-              fi
-              sleep 5
-            done
-            echo "Shard failed to become healthy after 300s"
-            docker logs rnode.validator1 2>&1 | tail -50
-            exit 1
-          else
-            echo "Waiting for standalone node to become healthy..."
-            for i in $(seq 1 60); do
-              if curl -sf http://localhost:40463/api/status >/dev/null 2>&1; then
-                echo "Node is healthy after $((i * 5))s"
-                exit 0
-              fi
-              sleep 5
-            done
-            echo "Node failed to become healthy after 300s"
-            docker logs rnode.standalone 2>&1 | tail -50
-            exit 1
-          fi
+          echo "Waiting for standalone node to become healthy..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:40463/api/status >/dev/null 2>&1; then
+              echo "Node is healthy after $((i * 5))s"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Node failed to become healthy after 300s"
+          docker logs rnode.standalone 2>&1 | tail -50
+          exit 1
 
       - name: Run Smoke Tests (bash)
         shell: bash -ex {0}
-        run: |
-          if [ "${{ matrix.node }}" = "rust" ]; then
-            # Shard: validator1 gRPC=40412, HTTP=40413, readonly gRPC=40452
-            ./scripts/smoke_test.sh localhost 40412 40413 40452
-          else
-            # Scala standalone: gRPC=40462, HTTP=40463
-            ./scripts/smoke_test.sh localhost 40462 40463
-          fi
+        run: ./scripts/smoke_test.sh localhost 40462 40463
 
       - name: Run Integration Tests (Rust)
         if: matrix.node == 'rust'
         shell: bash -ex {0}
         env:
-          F1R3FLY_HTTP_PORT: "40413"
-          F1R3FLY_OBSERVER_HTTP: "40453"
+          F1R3FLY_HTTP_PORT: "40463"
+          F1R3FLY_OBSERVER_HTTP: "40463"
         run: cargo test --test smoke --release -- --ignored
 
       - name: Upload Smoke Test Logs
@@ -396,13 +370,7 @@ jobs:
         shell: bash {0}
         run: |
           mkdir -p /tmp/docker-logs
-          if [ "${{ matrix.node }}" = "rust" ]; then
-            for name in bootstrap validator1 validator2 validator3 readonly; do
-              docker logs rnode.${name} > /tmp/docker-logs/${name}.log 2>&1 || true
-            done
-          else
-            docker logs rnode.standalone > /tmp/docker-logs/standalone.log 2>&1 || true
-          fi
+          docker logs rnode.standalone > /tmp/docker-logs/standalone.log 2>&1 || true
 
       - name: Upload Docker Logs
         if: always()
@@ -417,11 +385,10 @@ jobs:
         if: always()
         shell: bash {0}
         run: |
+          cd system-integration/integration-tests
           if [ "${{ matrix.node }}" = "rust" ]; then
-            cd system-integration
-            docker compose --env-file .env.node -f compose/f1r3node-rust.yml down -v
+            docker compose -f docker-compose.standalone-rust.yml down -v
           else
-            cd system-integration/integration-tests
             docker compose -f docker-compose.standalone-scala.yml down -v
           fi
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/F1R3FLY-io/f1r3node.git?tag=rust-v0.4.11#dca4619b3e031d5865f7c4fe0098d8b0a573cac1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1993,7 +1992,6 @@ dependencies = [
 [[package]]
 name = "models"
 version = "0.1.0"
-source = "git+https://github.com/F1R3FLY-io/f1r3node.git?tag=rust-v0.4.11#dca4619b3e031d5865f7c4fe0098d8b0a573cac1"
 dependencies = [
  "crypto",
  "hex",
@@ -2953,7 +2951,6 @@ dependencies = [
 [[package]]
 name = "rholang"
 version = "0.1.0"
-source = "git+https://github.com/F1R3FLY-io/f1r3node.git?tag=rust-v0.4.11#dca4619b3e031d5865f7c4fe0098d8b0a573cac1"
 dependencies = [
  "bincode",
  "cc",
@@ -3052,7 +3049,6 @@ dependencies = [
 [[package]]
 name = "rspace_plus_plus"
 version = "0.1.0"
-source = "git+https://github.com/F1R3FLY-io/f1r3node.git?tag=rust-v0.4.11#dca4619b3e031d5865f7c4fe0098d8b0a573cac1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3433,7 +3429,6 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/F1R3FLY-io/f1r3node.git?tag=rust-v0.4.11#dca4619b3e031d5865f7c4fe0098d8b0a573cac1"
 dependencies = [
  "axum",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2952,6 +2952,7 @@ dependencies = [
 name = "rholang"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "bincode",
  "cc",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
+source = "git+https://github.com/F1R3FLY-io/f1r3node.git?tag=rust-v0.4.13#95be4feb6b3594333b1675c6231d7b2bcffd51a6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1992,6 +1993,7 @@ dependencies = [
 [[package]]
 name = "models"
 version = "0.1.0"
+source = "git+https://github.com/F1R3FLY-io/f1r3node.git?tag=rust-v0.4.13#95be4feb6b3594333b1675c6231d7b2bcffd51a6"
 dependencies = [
  "crypto",
  "hex",
@@ -2951,6 +2953,7 @@ dependencies = [
 [[package]]
 name = "rholang"
 version = "0.1.0"
+source = "git+https://github.com/F1R3FLY-io/f1r3node.git?tag=rust-v0.4.13#95be4feb6b3594333b1675c6231d7b2bcffd51a6"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3050,6 +3053,7 @@ dependencies = [
 [[package]]
 name = "rspace_plus_plus"
 version = "0.1.0"
+source = "git+https://github.com/F1R3FLY-io/f1r3node.git?tag=rust-v0.4.13#95be4feb6b3594333b1675c6231d7b2bcffd51a6"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3430,6 +3434,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
+source = "git+https://github.com/F1R3FLY-io/f1r3node.git?tag=rust-v0.4.13#95be4feb6b3594333b1675c6231d7b2bcffd51a6"
 dependencies = [
  "axum",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ required-features = ["cli"]
 
 [dependencies]
 # F1r3fly protocol — using local path for development; switch back to git tag for release
-f1r3fly-models = { package = "models", path = "../f1r3node-rust/models" }
-f1r3fly-shared = { package = "shared", path = "../f1r3node-rust/shared" }
-f1r3fly-crypto = { package = "crypto", path = "../f1r3node-rust/crypto" }
-f1r3fly-rholang = { package = "rholang", path = "../f1r3node-rust/rholang" }
+f1r3fly-models = { package = "models", git = "https://github.com/F1R3FLY-io/f1r3node.git", tag = "rust-v0.4.13" }
+f1r3fly-shared = { package = "shared", git = "https://github.com/F1R3FLY-io/f1r3node.git", tag = "rust-v0.4.13" }
+f1r3fly-crypto = { package = "crypto", git = "https://github.com/F1R3FLY-io/f1r3node.git", tag = "rust-v0.4.13" }
+f1r3fly-rholang = { package = "rholang", git = "https://github.com/F1R3FLY-io/f1r3node.git", tag = "rust-v0.4.13" }
 prost = "0.14"
 
 # gRPC

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ name = "node_cli"
 required-features = ["cli"]
 
 [dependencies]
-# F1r3fly protocol
-f1r3fly-models = { package = "models", git = "https://github.com/F1R3FLY-io/f1r3node.git", tag = "rust-v0.4.11" }
-f1r3fly-shared = { package = "shared", git = "https://github.com/F1R3FLY-io/f1r3node.git", tag = "rust-v0.4.11" }
-f1r3fly-crypto = { package = "crypto", git = "https://github.com/F1R3FLY-io/f1r3node.git", tag = "rust-v0.4.11" }
-f1r3fly-rholang = { package = "rholang", git = "https://github.com/F1R3FLY-io/f1r3node.git", tag = "rust-v0.4.11" }
+# F1r3fly protocol — using local path for development; switch back to git tag for release
+f1r3fly-models = { package = "models", path = "../f1r3node-rust/models" }
+f1r3fly-shared = { package = "shared", path = "../f1r3node-rust/shared" }
+f1r3fly-crypto = { package = "crypto", path = "../f1r3node-rust/crypto" }
+f1r3fly-rholang = { package = "rholang", path = "../f1r3node-rust/rholang" }
 prost = "0.14"
 
 # gRPC

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "node_cli"
 required-features = ["cli"]
 
 [dependencies]
-# F1r3fly protocol — using local path for development; switch back to git tag for release
+# F1r3fly protocol types — pinned to a released f1r3node tag.
 f1r3fly-models = { package = "models", git = "https://github.com/F1R3FLY-io/f1r3node.git", tag = "rust-v0.4.13" }
 f1r3fly-shared = { package = "shared", git = "https://github.com/F1R3FLY-io/f1r3node.git", tag = "rust-v0.4.13" }
 f1r3fly-crypto = { package = "crypto", git = "https://github.com/F1R3FLY-io/f1r3node.git", tag = "rust-v0.4.13" }

--- a/README.md
+++ b/README.md
@@ -8,11 +8,17 @@ Rust crate for interacting with F1r3fly blockchain nodes. Usable as a **library*
 # Build
 cargo build --release
 
+# Check node status and native token info
+cargo run --release -- status -H localhost -p 40413
+
 # Deploy and wait for result
 cargo run --release -- deploy-and-wait -f contract.rho
 
 # Read-only query
 cargo run --release -- exploratory-deploy -f query.rho -H localhost -p 40452
+
+# Query native token metadata from on-chain contract
+cargo run --release -- exploratory-deploy -f rho_examples/query_token_metadata.rho -H localhost -p 40452
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ cargo run --release -- exploratory-deploy -f rho_examples/query_token_metadata.r
 - [Events](docs/library/events.md) -- WebSocket deploy finalization
 - [Architecture](docs/architecture.md) -- module structure, deploy flow, node endpoints
 
+### Testing
+- [Testing guide](docs/testing.md) -- integration tests (`cargo test --test smoke`) and CLI smoke test
+
 ## Environment Variables
 
 | Variable | Required | Default | Description |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cargo run --release -- exploratory-deploy -f query.rho -H localhost -p 40452
 - [transfer](docs/commands/transfer.md) -- transfer native tokens
 - [Node inspection](docs/commands/inspection.md) -- status, blocks, bonds, balance, etc.
 - [Key management](docs/commands/keys.md) -- generate keys, addresses
-- [Advanced](docs/commands/advanced.md) -- load-test, watch-blocks, dag, bond-validator
+- [Advanced](docs/commands/advanced.md) -- load-test, watch-events, dag, bond-validator
 
 ### Library
 - [Getting started](docs/library/getting-started.md) -- ConnectionManager API, config, examples

--- a/docs/DAG_VISUALIZATION_DESIGN.md
+++ b/docs/DAG_VISUALIZATION_DESIGN.md
@@ -261,7 +261,7 @@ pub struct DagApp {
     selected_index: usize,
     viewport_height: usize,
     show_details: bool,
-    ws_receiver: mpsc::Receiver<RChainEvent>,
+    ws_receiver: mpsc::Receiver<NodeEvent>,
     running: bool,
 }
 
@@ -314,7 +314,7 @@ Reuse existing WebSocket code from `commands/events.rs`:
 ```rust
 pub async fn spawn_event_listener(
     ws_url: String,
-    sender: mpsc::Sender<RChainEvent>,
+    sender: mpsc::Sender<NodeEvent>,
 ) -> Result<JoinHandle<()>> {
     tokio::spawn(async move {
         loop {

--- a/docs/commands/advanced.md
+++ b/docs/commands/advanced.md
@@ -49,7 +49,7 @@ Timeout:     0
 
 ## watch-events
 
-Monitor real-time node events via WebSocket. Connects to `/ws/events` and streams all 9 event types defined by the node. On connect, the node replays any startup events that occurred before the client connected.
+Monitor real-time node events via WebSocket. Connects to `/ws/events` and streams all 10 event types defined by the node. On connect, the node replays any startup events that occurred before the client connected.
 
 ```bash
 node_cli watch-events [-H HOST] [--http-port PORT] [--filter TYPE] [--retry-forever]
@@ -57,22 +57,24 @@ node_cli watch-events [-H HOST] [--http-port PORT] [--filter TYPE] [--retry-fore
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--filter` | all | `created`, `added`, `finalized`, `genesis`, or `lifecycle` |
+| `--filter` | all | `created`, `added`, `finalized`, `transfers`, `genesis`, or `lifecycle` |
 | `--retry-forever` | false | Reconnect indefinitely |
 
 ### Event types
 
 | Type | Filter | Description |
 |------|--------|-------------|
-| Block Created | `created` | Block proposed by a validator (hash, creator, seq-num, deploys) |
+| Block Created | `created` | Block proposed by a validator (hash, block#, timestamp, creator, deploys) |
 | Block Added | `added` | Block validated and added to the DAG |
 | Block Finalized | `finalized` | Block reached finalized status |
+| Transfers Available | `transfers` | Transfer extraction completed (readonly only, after block report) |
 | Sent Unapproved Block | `genesis` | Boot broadcasts genesis candidate to validators |
-| Block Approval Received | `genesis` | Boot receives approval from a validator |
 | Sent Approved Block | `genesis` | Boot broadcasts the approved genesis block |
 | Approved Block Received | `genesis` | Validator receives the approved genesis block |
 | Entered Running State | `lifecycle` | Node engine transitions to Running |
 | Node Started | `lifecycle` | Node HTTP server is ready |
+
+Block events include `Block #` (block number) and `Time` (timestamp). Transfer events show per-deploy transfer details (from/to/amount/success).
 
 ### Examples
 
@@ -80,27 +82,46 @@ node_cli watch-events [-H HOST] [--http-port PORT] [--filter TYPE] [--retry-fore
 $ node_cli watch-events
 
  Node Started
- Address: rnode://871fc407...@localhost?protocol=40400&discovery=40404
-
- Entered Running State
- Block: 37115b862d...
+ Address: rnode://24f31580...@rnode.validator1?protocol=40400&discovery=40404
 
  Block Created
- Hash:     7d88a8f291...
- Creator:  04ffc01657...
- Seq Num:  1
- Parents:  1
+ Hash:     25ad58ad271df3e5...
+ Block #:  134
+ Time:     1776898716907
+ Creator:  04fa70d7be5eb750...
+ Seq Num:  113
+ Parents:  3
  Deploys:  0
 
  Block Finalized
- Hash:     7d88a8f291...
+ Hash:     6dcbb0d170f5be7b...
+ Block #:  132
+ Time:     1776898685324
+ Creator:  0457febafcc25dd3...
+ Seq Num:  118
+ Parents:  3
+ Deploys:  0
+```
+
+On readonly nodes, transfer events appear after block finalization:
+
+```
+$ node_cli watch-events --http-port 40453
+
+ Transfers Available
+ Block:    edc71efd1dd41be6... (#130)
+ Deploys:  1
+   Deploy: 3044022015f80a59...  (1 transfers)
+     1111AtahZeefej4t -> 111127RX5ZgiAdRa : 100000000 (ok)
 ```
 
 ```
 $ node_cli watch-events --filter finalized
 
  Block Finalized
- Hash:     7d88a8f291...
+ Hash:     6dcbb0d170f5be7b...
+ Block #:  132
+ ...
 ```
 
 Auto-reconnects on disconnect (10 retries by default, indefinitely with `--retry-forever`).

--- a/docs/commands/advanced.md
+++ b/docs/commands/advanced.md
@@ -47,42 +47,60 @@ Orphaned:    0
 Timeout:     0
 ```
 
-## watch-blocks
+## watch-events
 
-Monitor real-time block events via WebSocket.
+Monitor real-time node events via WebSocket. Connects to `/ws/events` and streams all 9 event types defined by the node. On connect, the node replays any startup events that occurred before the client connected.
 
 ```bash
-node_cli watch-blocks [-H HOST] [--http-port PORT] [--filter TYPE] [--retry-forever]
+node_cli watch-events [-H HOST] [--http-port PORT] [--filter TYPE] [--retry-forever]
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--filter` | all | `created`, `added`, or `finalized` |
+| `--filter` | all | `created`, `added`, `finalized`, `genesis`, or `lifecycle` |
 | `--retry-forever` | false | Reconnect indefinitely |
 
-Three event types are streamed:
+### Event types
 
-- **Block Created** -- new block proposed by a validator. Includes block hash, creator, sequence number, parent hashes, and deploy IDs.
-- **Block Added** -- block validated and added to the DAG by a receiving node. Same fields as Created.
-- **Block Finalized** -- block reached finalized status (confirmed by consensus). Includes block hash, deploys with cost and errored status.
+| Type | Filter | Description |
+|------|--------|-------------|
+| Block Created | `created` | Block proposed by a validator (hash, creator, seq-num, deploys) |
+| Block Added | `added` | Block validated and added to the DAG |
+| Block Finalized | `finalized` | Block reached finalized status |
+| Sent Unapproved Block | `genesis` | Boot broadcasts genesis candidate to validators |
+| Block Approval Received | `genesis` | Boot receives approval from a validator |
+| Sent Approved Block | `genesis` | Boot broadcasts the approved genesis block |
+| Approved Block Received | `genesis` | Validator receives the approved genesis block |
+| Entered Running State | `lifecycle` | Node engine transitions to Running |
+| Node Started | `lifecycle` | Node HTTP server is ready |
 
-```
-$ node_cli watch-blocks
-
-Connected to node WebSocket
-Watching for block events...
-
-Block Created: a1b2c3d4... (creator: 0457feba..., seq: 293, deploys: 0, parents: 3)
-Block Added: a1b2c3d4... (creator: 0457feba..., seq: 293, deploys: 0, parents: 3)
-Block Added: e5f6a7b8... (creator: 04837a4c..., seq: 297, deploys: 0, parents: 3)
-Block Finalized: 9c0d1e2f...
-```
+### Examples
 
 ```
-$ node_cli watch-blocks --filter finalized
+$ node_cli watch-events
 
-Block Finalized: 9c0d1e2f...
-Block Finalized: 3a4b5c6d...
+ Node Started
+ Address: rnode://871fc407...@localhost?protocol=40400&discovery=40404
+
+ Entered Running State
+ Block: 37115b862d...
+
+ Block Created
+ Hash:     7d88a8f291...
+ Creator:  04ffc01657...
+ Seq Num:  1
+ Parents:  1
+ Deploys:  0
+
+ Block Finalized
+ Hash:     7d88a8f291...
+```
+
+```
+$ node_cli watch-events --filter finalized
+
+ Block Finalized
+ Hash:     7d88a8f291...
 ```
 
 Auto-reconnects on disconnect (10 retries by default, indefinitely with `--retry-forever`).

--- a/docs/commands/exploratory-deploy.md
+++ b/docs/commands/exploratory-deploy.md
@@ -36,6 +36,29 @@ No data returned
 
 The response now includes the phlogiston cost of execution. For cost-only output, use [estimate-cost](estimate-cost.md).
 
+## Querying native token metadata
+
+The node's `TokenMetadata` contract (registered at `rho:system:tokenMetadata`) can be queried via exploratory deploy. An example Rholang file is included at `rho_examples/query_token_metadata.rho`:
+
+```
+$ node_cli exploratory-deploy -H localhost -p 40452 -f rho_examples/query_token_metadata.rho
+
+Execution successful!
+Cost:    34218 phlogiston
+Time:    107.11ms
+Block hash: 579fbb0b..., Block number: 48
+Result:
+("F1R3CAP", "F1R3", 8)
+```
+
+The contract supports four methods:
+- `TokenMetadata!("name", *ret)` — returns the full token name as a string
+- `TokenMetadata!("symbol", *ret)` — returns the ticker symbol as a string
+- `TokenMetadata!("decimals", *ret)` — returns the decimal places as an integer
+- `TokenMetadata!("all", *ret)` — returns a `(name, symbol, decimals)` tuple
+
+These values are baked into genesis and are immutable for the lifetime of the network.
+
 ## Notes
 
 - Must run against a read-only or observer node (validators may reject exploratory deploys)

--- a/docs/commands/get-deploy.md
+++ b/docs/commands/get-deploy.md
@@ -1,6 +1,6 @@
 # get-deploy
 
-Get deploy information by deploy ID. Tries the detail view first (Rust node v0.4.11+), falls back to basic view on older or Scala nodes.
+Get deploy information by deploy ID. Returns the unified `DeployResponse` with all execution details.
 
 ## Usage
 
@@ -16,77 +16,53 @@ node_cli get-deploy --deploy-id <ID> [OPTIONS]
 | `--host` | `-H` | `localhost` | Node hostname |
 | `--http-port` | | `40413` | HTTP port |
 | `--format` | | `pretty` | Output format: `pretty`, `json`, `summary` |
-| `--verbose` | `-v` | false | Show signature and VABN in pretty mode |
+| `--verbose` | `-v` | false | Show VABN in pretty mode |
 
-## Example: Detail view (Rust node v0.4.11+)
+## Example
 
 ```
-$ node_cli get-deploy --deploy-id 3044022075e51b8f...
+$ node_cli get-deploy -d 304502210085f163...
 
 Deploy Information
 ----------------------------------------
-Deploy ID:    3044022075e51b8f...
-Block Hash:   0519f656624c26e8a406ed4fd7f1fa9327f48128a0ad7758289bc09b8f646419
-Block Number: 314
+Deploy ID:    304502210085f163934f0de4c8eadb177d62b9527997100ff3b80d868dbfa702c2...
+Block Hash:   79d3560b36998644d139ba0f73a3883274f28f22b6f2016e973f3606be38bb56
+Block Number: 130
+Finalized:    true
 Deployer:     04ffc016579a68050d655d55df4e09f04605164543e257c8e6df10361e6068a533...
-Cost:         316
+Cost:         317
 Errored:      false
 Phlo Price:   1
 Phlo Limit:   50000
-Timestamp:    1775610628069
+Timestamp:    1776898667421
 Sig Algo:     secp256k1
-Query time:   30.57ms
+Query time:   15.38ms
 ```
 
-## Example: Basic view (older nodes / Scala)
+## Response Fields
 
-When the node doesn't support the detail view, the command falls back:
+| Field | Always present | Description |
+|-------|---------------|-------------|
+| `deployId` | Yes | Deploy signature ID |
+| `blockHash` | Yes | Containing block hash |
+| `blockNumber` | Yes | Block height |
+| `timestamp` | Yes | Block timestamp |
+| `cost` | Yes | Phlogiston consumed |
+| `errored` | Yes | Whether execution failed |
+| `isFinalized` | Yes | Whether containing block is finalized |
+| `deployer` | Full view | Deployer public key |
+| `term` | Full view | Rholang source |
+| `systemDeployError` | Full view | System deploy error (empty if none) |
+| `phloPrice` | Full view | Phlogiston price |
+| `phloLimit` | Full view | Phlogiston limit |
+| `sigAlgorithm` | Full view | Signature algorithm |
+| `validAfterBlockNumber` | Full view | Valid-after constraint |
+| `transfers` | Full view | Transfer list (null on validators, populated on readonly) |
 
-```
-$ node_cli get-deploy --deploy-id 3044022075e51b8f...
-
-Deploy Information (basic view)
-----------------------------------------
-Deploy ID:    3044022075e51b8f...
-Block Hash:   0519f656624c26e8...
-Block Number: 314
-Sender:       04ffc016579a6805...
-Timestamp:    1775610628069
-Query time:   12.31ms
-
-Note: deploy execution details (cost, errored) require Rust node v0.4.11+
-```
-
-## Example: JSON format
-
-On nodes with detail view, returns `DeployDetail`. On older nodes, returns raw block metadata JSON.
-
-```
-$ node_cli get-deploy --deploy-id 3044022075e51b8f... --format json
-
-{
-  "blockHash": "0519f656624c26e8...",
-  "blockNumber": 314,
-  "cost": 316,
-  "errored": false,
-  "deployer": "04ffc016579a680...",
-  ...
-}
-```
-
-## Example: Summary format
+## Summary format
 
 ```
-$ node_cli get-deploy --deploy-id 3044022075e51b8f... --format summary
+$ node_cli get-deploy -d 304502210085f163... --format summary
 
-Deploy 3044022075e51b8f... in block 0519f656... (#314) cost=316 errored=false
+Deploy 304502210085f163... in block 79d3560b... (#130) cost=317 errored=false finalized=true
 ```
-
-## Node Views
-
-The command tries views in order:
-
-| View | Endpoint | Available on | What it returns |
-|------|----------|-------------|-----------------|
-| detail | `?view=detail` | Rust v0.4.11+ | cost, errored, deployer, phlo, blockNumber |
-| default | (no param) | All nodes | blockHash, seqNum, sender, timestamp |

--- a/docs/commands/inspection.md
+++ b/docs/commands/inspection.md
@@ -20,33 +20,22 @@ $ node_cli status -H localhost -p 40413
   Nodes:         4
   Min Phlo:      1
   Native Token:  F1R3CAP (F1R3, 8 decimals)
+  LFB Number:    126
+  Validator:     false
+  Read Only:     false
+  Ready:         true
+  Epoch:         12 (length: 10)
   Version:       {"api":"1","node":"F1r3node Rust 0.4.10 ()"}
 ```
 
-The **Native Token** line shows the chain's native token identity configured at genesis:
-- **Name** — full display name (e.g. `F1R3CAP`)
-- **Symbol** — ticker symbol (e.g. `F1R3`)
-- **Decimals** — 1 token = 10^decimals dust (e.g. `8` means 100,000,000 dust per token)
-
-These values are baked into the on-chain `TokenMetadata` contract at genesis and are immutable. They can also be queried from Rholang via exploratory deploy (see [exploratory-deploy](./exploratory-deploy.md)).
-
-### Raw JSON response
-
-```json
-{
-  "version": {"api": "1", "node": "F1r3node Rust 0.4.10 ()"},
-  "address": "rnode://24f31580...@rnode.validator1?protocol=40400&discovery=40404",
-  "networkId": "testnet",
-  "shardId": "root",
-  "peers": 4,
-  "nodes": 4,
-  "minPhloPrice": 1,
-  "nativeTokenName": "F1R3CAP",
-  "nativeTokenSymbol": "F1R3",
-  "nativeTokenDecimals": 8,
-  "peerList": [...]
-}
-```
+| Field | Description |
+|-------|-------------|
+| Native Token | Name, symbol, decimals — baked into genesis, immutable |
+| LFB Number | Last finalized block number (-1 if not yet initialized) |
+| Validator | Whether this node can propose blocks |
+| Read Only | Whether this node is in read-only mode |
+| Ready | Whether the engine has entered Running state |
+| Epoch | Current epoch and epoch length from genesis config |
 
 ## blocks
 
@@ -64,16 +53,21 @@ $ node_cli blocks -n 1
 
 [
   {
-    "blockHash": "c6f93059d8bb3a0a...",
-    "blockNumber": 402,
-    "deployCount": 0,
-    "faultTolerance": 0.0,
-    "sender": "0457febafcc25dd3...",
-    "timestamp": 1775611821639,
-    ...
+    "blockInfo": {
+      "blockHash": "a47bdb405fc3ccba...",
+      "blockNumber": 128,
+      "isFinalized": true,
+      "faultTolerance": 1.0,
+      "sender": "0457febafcc25dd3...",
+      "timestamp": 1776898700000,
+      "deployCount": 0,
+      ...
+    }
   }
 ]
 ```
+
+Block list responses use the `blockInfo` wrapper (summary view by default, deploys omitted).
 
 ## last-finalized-block
 

--- a/docs/commands/inspection.md
+++ b/docs/commands/inspection.md
@@ -8,21 +8,43 @@ HTTP-based commands for querying node state.
 node_cli status [-H HOST] [-p HTTP_PORT]
 ```
 
-```
-$ node_cli status
+Queries the node's `/api/status` endpoint and displays node identity, network membership, and native token metadata.
 
-Node Status:
+```
+$ node_cli status -H localhost -p 40413
+
+  Address:       rnode://24f31580...@rnode.validator1?protocol=40400&discovery=40404
+  Network:       testnet
+  Shard:         root
+  Peers:         4
+  Nodes:         4
+  Min Phlo:      1
+  Native Token:  F1R3CAP (F1R3, 8 decimals)
+  Version:       {"api":"1","node":"F1r3node Rust 0.4.10 ()"}
+```
+
+The **Native Token** line shows the chain's native token identity configured at genesis:
+- **Name** — full display name (e.g. `F1R3CAP`)
+- **Symbol** — ticker symbol (e.g. `F1R3`)
+- **Decimals** — 1 token = 10^decimals dust (e.g. `8` means 100,000,000 dust per token)
+
+These values are baked into the on-chain `TokenMetadata` contract at genesis and are immutable. They can also be queried from Rholang via exploratory deploy (see [exploratory-deploy](./exploratory-deploy.md)).
+
+### Raw JSON response
+
+```json
 {
+  "version": {"api": "1", "node": "F1r3node Rust 0.4.10 ()"},
   "address": "rnode://24f31580...@rnode.validator1?protocol=40400&discovery=40404",
-  "nodes": 4,
+  "networkId": "testnet",
+  "shardId": "root",
   "peers": 4,
-  "version": "F1r3node Rust 0.4.10 ()",
-  "peerList": [
-    { "host": "rnode.validator2", "isConnected": true, ... },
-    { "host": "rnode.validator3", "isConnected": true, ... },
-    { "host": "rnode.bootstrap", "isConnected": true, ... },
-    { "host": "rnode.readonly", "isConnected": true, ... }
-  ]
+  "nodes": 4,
+  "minPhloPrice": 1,
+  "nativeTokenName": "F1R3CAP",
+  "nativeTokenSymbol": "F1R3",
+  "nativeTokenDecimals": 8,
+  "peerList": [...]
 }
 ```
 

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -1,0 +1,20 @@
+# Deferred Rust Client Work
+
+## Gap 3: Registry Command
+
+Add `registry` CLI command wrapping `GET /api/registry/{uri}`. Currently no way to look up a registry URI from the CLI — users must use `exploratory-deploy` with raw Rholang.
+
+## Gap 4: Use Dedicated HTTP Endpoints
+
+These commands currently construct Rholang and use exploratory deploy. They could use the new dedicated HTTP endpoints instead, which are simpler and in some cases don't require readonly nodes:
+
+| Command | Current approach | Dedicated endpoint | Benefit |
+|---|---|---|---|
+| `bonds` | HTTP explore-deploy with `@PoS!("getBonds")` | `GET /api/validators` | Simpler, structured response |
+| `epoch-info` | gRPC explore-deploy with `getEpochLength`/`getQuarantineLength` | `GET /api/epoch` | No readonly needed, faster |
+| `bond-status` | HTTP explore-deploy, parse bonds map | `GET /api/bond-status/{pubkey}` | No readonly needed |
+| `validator-status` | Multiple explore-deploys | `GET /api/validator/{pubkey}` | Single request |
+| `epoch-rewards` | HTTP explore-deploy with `getCurrentEpochRewards` | `GET /api/epoch/rewards` | Simpler |
+| `estimate-cost` | gRPC exploratory deploy | `POST /api/estimate-cost` | Could use HTTP instead |
+
+The existing approach works correctly. Migration is an optimization.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,95 @@
+# Testing
+
+## Integration Tests (`tests/smoke.rs`)
+
+Rust integration tests that verify all HTTP API endpoints against a running shard. These test the API responses directly using `reqwest`, with structured assertions on JSON field types, values, and relationships.
+
+### Running
+
+```bash
+# Requires a running shard (docker compose or standalone)
+cargo test --test smoke --release
+
+# With custom ports
+F1R3FLY_HTTP_PORT=40403 F1R3FLY_OBSERVER_HTTP=40453 cargo test --test smoke --release
+
+# Single test
+cargo test --test smoke test_status_fields --release
+```
+
+Tests skip gracefully if no shard is reachable — `cargo test` always succeeds, tests just return `Ok(())`.
+
+### Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `F1R3FLY_HOST` | `localhost` | Node hostname |
+| `F1R3FLY_HTTP_PORT` | `40413` | Validator HTTP port |
+| `F1R3FLY_OBSERVER_HTTP` | `40453` | Readonly HTTP port |
+
+### Test Coverage (24 tests)
+
+| Category | Tests | What's verified |
+|---|---|---|
+| Status | 1 | All 17 fields, types, `isReady=true`, `epochLength>0` |
+| Blocks (single) | 3 | Full/summary views, `isFinalized`, hash match |
+| Blocks (list) | 3 | Summary default (no deploys), full view, height range |
+| is-finalized | 1 | Returns `true` for LFB |
+| prepare-deploy | 1 | `seqNumber`, `names` present |
+| explore-deploy | 1 | `cost>0`, `expr`, `block` |
+| Epoch | 2 | All fields, derived `currentEpoch` check, `?block_hash=` param |
+| Validators | 2 | Bonded (real pubkey), unknown (fake pubkey) |
+| Bond status | 2 | Bonded on validator node, unknown returns false |
+| Epoch rewards | 1 | ExprMap structure |
+| Estimate cost | 2 | Valid term returns cost, invalid syntax returns error |
+| Removed endpoints | 2 | `/data-at-name` and `/transactions` return 404 |
+| Edge cases | 1 | Unknown `?view=` falls back to full |
+
+### What's NOT covered
+
+- `POST /deploy` — requires deploy signing
+- `GET /deploy/{id}` — requires prior deploy
+- `GET /balance/{address}` — requires REV address with vault
+- `GET /registry/{uri}` — requires deployed contract
+- WebSocket events — requires async WS client
+- gRPC endpoints — covered by system-integration integration tests
+
+## Smoke Test Script (`scripts/smoke_test.sh`)
+
+Bash script that tests the **CLI binary** end-to-end. Builds the binary, runs each command, and validates output against regex patterns.
+
+```bash
+# Against a shard (validator1 on 40412/40413, readonly on 40452/40453)
+./scripts/smoke_test.sh localhost 40412 40413 40452
+
+# Against standalone node
+./scripts/smoke_test.sh localhost 40402 40403
+```
+
+### What it tests
+
+The smoke test covers all CLI commands including deploy, propose, transfer, and load testing — operations that require signing and multi-step workflows that the Rust integration tests don't cover.
+
+It also tests the new HTTP endpoints directly via `curl`:
+- `/api/epoch`, `/api/validators`, `/api/bond-status`, `/api/estimate-cost`
+- `/api/deploy/{id}?view=summary` (summary view)
+- Removed endpoints return 404
+
+### Limitations
+
+- Output validation is regex-based (fragile when display format changes)
+- Sequential execution (~5 min for full suite)
+- Some tests depend on earlier test results (deploy ID cascading)
+- Transfer test can fail under load (finalization timeout)
+
+### Complementary testing
+
+| Concern | `tests/smoke.rs` | `scripts/smoke_test.sh` |
+|---|---|---|
+| API response structure | Yes (typed JSON) | No (regex on CLI output) |
+| CLI argument parsing | No | Yes |
+| Deploy signing flow | No | Yes |
+| Transfer end-to-end | No | Yes |
+| Load testing | No | Yes |
+| WebSocket display | No | Yes (10s capture) |
+| Speed | 0.3s | ~5 min |

--- a/rho_examples/query_token_metadata.rho
+++ b/rho_examples/query_token_metadata.rho
@@ -1,0 +1,15 @@
+// Query the native token metadata from the on-chain TokenMetadata contract.
+// Returns a tuple (name, symbol, decimals) on the return channel.
+//
+// Usage:
+//   node_cli exploratory-deploy -H localhost -p 40402 -f rho_examples/query_token_metadata.rho
+//
+// Expected output on a default F1R3FLY chain:
+//   ("F1R3CAP", "F1R3", 8)
+
+new ret, rl(`rho:registry:lookup`), tmCh in {
+  rl!(`rho:system:tokenMetadata`, *tmCh) |
+  for (@(_, TokenMetadata) <- tmCh) {
+    @TokenMetadata!("all", *ret)
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,7 +47,7 @@ The smoke test validates 30+ commands across these categories:
 | **Network** | network-health, bond-status |
 | **Transfer** | transfer, get-deploy |
 | **PoS Queries** | epoch-info, epoch-rewards, validator-status, network-consensus |
-| **Streaming** | watch-blocks (verifies Block Created, Added, and Finalized events) |
+| **Streaming** | watch-events (verifies block lifecycle, genesis, and node lifecycle events) |
 | **Load Testing** | load-test (runs 3 transfers, requires 100% finalization) |
 
 ---

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -346,9 +346,10 @@ echo ""
 echo -e "${BLUE}--- Node Inspection Commands (HTTP) ---${NC}"
 
 # status: Get node status and peer information
+# Validates new fields: LFB Number, Ready, Epoch
 run_test "status" \
     "cargo run -q --release -- status -H $HOST -p $HTTP_PORT" \
-    "Node status retrieved successfully|Native Token:"
+    "Node status retrieved successfully|LFB Number:"
 
 # blocks: Get recent blocks
 run_test "blocks" \
@@ -412,7 +413,11 @@ run_test "network-health" \
 
 # bond-status: Check if a validator is bonded
 # Uses exploratory-deploy internally, must run on observer (read-only) node
-VALIDATOR_PUBKEY="04ffc016579a68050d655d55df4e09f04605164543e257c8e6df10361e6068a5336588e9b355ea859c5ab4285a5ef0efdf62bc28b80320ce99e26bb1607b3ad93d"
+# Get a real validator pubkey from the node's status endpoint
+VALIDATOR_PUBKEY=$(curl -s "http://$HOST:$HTTP_PORT/api/last-finalized-block" 2>/dev/null | grep -oE '"validator":"[0-9a-f]+"' | head -1 | cut -d'"' -f4 || echo "")
+if [ -z "$VALIDATOR_PUBKEY" ]; then
+    VALIDATOR_PUBKEY="04ffc016579a68050d655d55df4e09f04605164543e257c8e6df10361e6068a5336588e9b355ea859c5ab4285a5ef0efdf62bc28b80320ce99e26bb1607b3ad93d"
+fi
 run_test "bond-status" \
     "cargo run -q --release -- bond-status -H $HOST -p $OBSERVER_HTTP -k $VALIDATOR_PUBKEY" \
     "Bond information retrieved successfully|BONDED|NOT BONDED"
@@ -427,15 +432,16 @@ echo -e "${BLUE}--- Transfer Commands ---${NC}"
 # Uses ConnectionManager with full_deploy_and_wait (deploy -> finalize -> read)
 echo -n "Testing transfer... "
 TRANSFER_START=$(date +%s.%N)
-if cargo run -q --release -- transfer --to-address 111127RX5ZgiAdRaQy4AWy57RdvAAckdELReEBxzvWYVvdnR32PiHA --amount 1 -H $HOST -p $GRPC_PORT --http-port $HTTP_PORT --observer-port $OBSERVER_GRPC --max-wait 60 --check-interval 2 > "$OUTPUT" 2>&1; then
+if cargo run -q --release -- transfer --to-address 111127RX5ZgiAdRaQy4AWy57RdvAAckdELReEBxzvWYVvdnR32PiHA --amount 1 -H $HOST -p $GRPC_PORT --http-port $HTTP_PORT --observer-port $OBSERVER_GRPC --max-wait 120 --check-interval 2 > "$OUTPUT" 2>&1; then
     TRANSFER_END=$(date +%s.%N)
     TRANSFER_MS=$(echo "($TRANSFER_END - $TRANSFER_START) * 1000" | bc | cut -d. -f1)
     save_log "transfer"
     if grep -qE "Deploy ID:|Transfer complete|Transfer failed" "$OUTPUT"; then
         echo -e "${GREEN}PASS${NC} [$(format_duration $TRANSFER_MS)]"
         inc_pass
-        # Extract deploy ID for get-deploy test
+        # Extract deploy ID and block hash for subsequent tests
         TRANSFER_DEPLOY_ID=$(grep "Deploy ID:" "$OUTPUT" | head -1 | awk '{print $NF}' || echo "")
+        TRANSFER_BLOCK_HASH=$(grep "Block hash:" "$OUTPUT" | head -1 | awk '{print $NF}' || echo "")
     else
         echo -e "${RED}FAIL${NC} (output validation failed) [$(format_duration $TRANSFER_MS)]"
         head -10 "$OUTPUT" | sed 's/^/    /'
@@ -450,12 +456,93 @@ else
     inc_fail
 fi
 
+# transfer-info: Verify transfer data in block API on readonly
+# The readonly node extracts transfers via block replay (BlockReportAPI)
+if [ -n "${TRANSFER_BLOCK_HASH:-}" ]; then
+    echo -n "Testing transfer-info (readonly)... "
+    TI_START=$(date +%s.%N)
+    # Poll readonly for transfers (block report may need a moment to warm cache)
+    TI_FOUND=false
+    for attempt in 1 2 3 4 5 6; do
+        TI_RESP=$(curl -s "http://$HOST:$OBSERVER_HTTP/api/block/$TRANSFER_BLOCK_HASH" 2>/dev/null)
+        if echo "$TI_RESP" | grep -q '"fromAddr"'; then
+            TI_FOUND=true
+            break
+        fi
+        sleep 3
+    done
+    TI_END=$(date +%s.%N)
+    TI_MS=$(echo "($TI_END - $TI_START) * 1000" | bc | cut -d. -f1)
+    save_log "transfer-info"
+    if $TI_FOUND; then
+        # Verify transfer fields
+        HAS_FROM=$(echo "$TI_RESP" | grep -c '"fromAddr"' || echo 0)
+        HAS_TO=$(echo "$TI_RESP" | grep -c '"toAddr"' || echo 0)
+        HAS_AMOUNT=$(echo "$TI_RESP" | grep -c '"amount"' || echo 0)
+        HAS_SUCCESS=$(echo "$TI_RESP" | grep -c '"success":true' || echo 0)
+        if [ "$HAS_FROM" -gt 0 ] && [ "$HAS_TO" -gt 0 ] && [ "$HAS_AMOUNT" -gt 0 ] && [ "$HAS_SUCCESS" -gt 0 ]; then
+            echo -e "${GREEN}PASS${NC} (transfers found with from/to/amount/success) [$(format_duration $TI_MS)]"
+            inc_pass
+        else
+            echo -e "${RED}FAIL${NC} (transfer fields incomplete) [$(format_duration $TI_MS)]"
+            echo "  from:$HAS_FROM to:$HAS_TO amount:$HAS_AMOUNT success:$HAS_SUCCESS"
+            inc_fail
+        fi
+    else
+        echo -e "${RED}FAIL${NC} (no transfers in block on readonly after 6 attempts) [$(format_duration $TI_MS)]"
+        inc_fail
+    fi
+
+    # Verify transfers are null on validator (not readonly)
+    echo -n "Testing transfer-info (validator=null)... "
+    TV_RESP=$(curl -s "http://$HOST:$HTTP_PORT/api/block/$TRANSFER_BLOCK_HASH" 2>/dev/null)
+    if echo "$TV_RESP" | grep -q '"transfers":null' || ! echo "$TV_RESP" | grep -q '"fromAddr"'; then
+        echo -e "${GREEN}PASS${NC} (transfers null on validator)"
+        inc_pass
+    else
+        echo -e "${RED}FAIL${NC} (transfers should be null on validator)"
+        inc_fail
+    fi
+else
+    skip_test "transfer-info (readonly)" "no block hash from transfer test"
+    skip_test "transfer-info (validator=null)" "no block hash from transfer test"
+fi
+
+# transfers-available WS event: Connect to readonly WS, submit transfer, verify event
+echo -n "Testing transfers-available (WS)... "
+TA_START=$(date +%s.%N)
+# Start WS listener on readonly in background
+TA_WS_OUT=$(mktemp)
+run_with_timeout 30 cargo run -q --release -- watch-events -H $HOST --http-port $OBSERVER_HTTP > "$TA_WS_OUT" 2>&1 &
+TA_WS_PID=$!
+sleep 3  # Let WS connect
+
+# Submit a transfer
+cargo run -q --release -- transfer --to-address 111127RX5ZgiAdRaQy4AWy57RdvAAckdELReEBxzvWYVvdnR32PiHA --amount 1 -H $HOST -p $GRPC_PORT --http-port $HTTP_PORT --observer-port $OBSERVER_GRPC --max-wait 120 --check-interval 2 > /dev/null 2>&1 || true
+
+# Wait for WS to capture events (up to remaining time)
+wait $TA_WS_PID 2>/dev/null || true
+TA_END=$(date +%s.%N)
+TA_MS=$(echo "($TA_END - $TA_START) * 1000" | bc | cut -d. -f1)
+
+if grep -q "Transfers Available" "$TA_WS_OUT"; then
+    echo -e "${GREEN}PASS${NC} (transfers-available event received on readonly) [$(format_duration $TA_MS)]"
+    inc_pass
+else
+    echo -e "${RED}FAIL${NC} (no transfers-available event on readonly WS) [$(format_duration $TA_MS)]"
+    echo "  Events received:"
+    grep -c "Block " "$TA_WS_OUT" 2>/dev/null | sed 's/^/    blocks: /' || true
+    grep "Transfers" "$TA_WS_OUT" 2>/dev/null | head -3 | sed 's/^/    /' || true
+    inc_fail
+fi
+rm -f "$TA_WS_OUT"
+
 # get-deploy: Get deploy execution details (cost, errored, blockNumber)
 # Uses deploy ID from deploy-and-wait (with data) test
 if [ -n "${FDAW_DEPLOY_ID:-}" ]; then
     run_test "get-deploy" \
         "cargo run -q --release -- get-deploy -d $FDAW_DEPLOY_ID -H $HOST --http-port $HTTP_PORT" \
-        "Deploy Information|Block Number:|Cost:|Deploy ID:|in block"
+        "Deploy Information|Block Number:|Cost:|Deploy ID:|Finalized:"
 else
     # Fail, not skip — if we can't get a deploy ID something is wrong
     echo -n "Testing get-deploy... "
@@ -494,6 +581,109 @@ run_test "network-consensus" \
     "Network consensus data retrieved successfully|Consensus Health"
 
 # ============================================
+# NEW HTTP ENDPOINT TESTS (direct curl)
+# ============================================
+echo ""
+echo -e "${BLUE}--- New HTTP Endpoints ---${NC}"
+
+# /api/epoch: Available on all node types (no exploratory deploy)
+echo -n "Testing /api/epoch... "
+EPOCH_START=$(date +%s.%N)
+EPOCH_RESP=$(curl -s "http://$HOST:$HTTP_PORT/api/epoch" 2>/dev/null)
+EPOCH_END=$(date +%s.%N)
+EPOCH_MS=$(echo "($EPOCH_END - $EPOCH_START) * 1000" | bc | cut -d. -f1)
+if echo "$EPOCH_RESP" | grep -q '"epochLength"'; then
+    EPOCH_LEN=$(echo "$EPOCH_RESP" | grep -oE '"epochLength":[0-9]+' | cut -d: -f2)
+    echo -e "${GREEN}PASS${NC} (epochLength=$EPOCH_LEN) [$(format_duration $EPOCH_MS)]"
+    inc_pass
+else
+    echo -e "${RED}FAIL${NC} [$(format_duration $EPOCH_MS)]"
+    echo "  Response: $EPOCH_RESP"
+    inc_fail
+fi
+
+# /api/validators: Readonly only
+echo -n "Testing /api/validators... "
+VAL_START=$(date +%s.%N)
+VAL_RESP=$(curl -s "http://$HOST:$OBSERVER_HTTP/api/validators" 2>/dev/null)
+VAL_END=$(date +%s.%N)
+VAL_MS=$(echo "($VAL_END - $VAL_START) * 1000" | bc | cut -d. -f1)
+if echo "$VAL_RESP" | grep -q '"totalStake"'; then
+    TOTAL=$(echo "$VAL_RESP" | grep -oE '"totalStake":[0-9]+' | cut -d: -f2)
+    echo -e "${GREEN}PASS${NC} (totalStake=$TOTAL) [$(format_duration $VAL_MS)]"
+    inc_pass
+else
+    echo -e "${RED}FAIL${NC} [$(format_duration $VAL_MS)]"
+    echo "  Response: ${VAL_RESP:0:200}"
+    inc_fail
+fi
+
+# /api/bond-status/{pubkey}: Available on all node types
+echo -n "Testing /api/bond-status... "
+BS_START=$(date +%s.%N)
+BS_RESP=$(curl -s "http://$HOST:$HTTP_PORT/api/bond-status/$VALIDATOR_PUBKEY" 2>/dev/null)
+BS_END=$(date +%s.%N)
+BS_MS=$(echo "($BS_END - $BS_START) * 1000" | bc | cut -d. -f1)
+if echo "$BS_RESP" | grep -q '"isBonded":true'; then
+    echo -e "${GREEN}PASS${NC} (isBonded=true) [$(format_duration $BS_MS)]"
+    inc_pass
+else
+    echo -e "${RED}FAIL${NC} [$(format_duration $BS_MS)]"
+    echo "  Response: $BS_RESP"
+    inc_fail
+fi
+
+# /api/estimate-cost: Readonly only
+echo -n "Testing /api/estimate-cost... "
+EC_START=$(date +%s.%N)
+EC_RESP=$(curl -s -X POST "http://$HOST:$OBSERVER_HTTP/api/estimate-cost" \
+    -H 'Content-Type: application/json' \
+    -d '{"term": "new ret in { ret!(42) }"}' 2>/dev/null)
+EC_END=$(date +%s.%N)
+EC_MS=$(echo "($EC_END - $EC_START) * 1000" | bc | cut -d. -f1)
+if echo "$EC_RESP" | grep -q '"cost"'; then
+    COST=$(echo "$EC_RESP" | grep -oE '"cost":[0-9]+' | cut -d: -f2)
+    echo -e "${GREEN}PASS${NC} (cost=$COST) [$(format_duration $EC_MS)]"
+    inc_pass
+else
+    echo -e "${RED}FAIL${NC} [$(format_duration $EC_MS)]"
+    echo "  Response: ${EC_RESP:0:200}"
+    inc_fail
+fi
+
+# /api/deploy/{id}?view=summary: Summary view
+if [ -n "${FDAW_DEPLOY_ID:-}" ]; then
+    echo -n "Testing /api/deploy (summary view)... "
+    SV_START=$(date +%s.%N)
+    SV_RESP=$(curl -s "http://$HOST:$HTTP_PORT/api/deploy/$FDAW_DEPLOY_ID?view=summary" 2>/dev/null)
+    SV_END=$(date +%s.%N)
+    SV_MS=$(echo "($SV_END - $SV_START) * 1000" | bc | cut -d. -f1)
+    if echo "$SV_RESP" | grep -q '"deployId"' && ! echo "$SV_RESP" | grep -q '"deployer"'; then
+        echo -e "${GREEN}PASS${NC} (has deployId, no deployer) [$(format_duration $SV_MS)]"
+        inc_pass
+    else
+        echo -e "${RED}FAIL${NC} [$(format_duration $SV_MS)]"
+        echo "  Response: ${SV_RESP:0:200}"
+        inc_fail
+    fi
+else
+    skip_test "/api/deploy (summary view)" "no deploy ID from earlier tests"
+fi
+
+# Removed endpoints return 404
+echo -n "Testing removed endpoints return 404... "
+R1=$(curl -s -o /dev/null -w "%{http_code}" -X POST "http://$HOST:$HTTP_PORT/api/data-at-name" \
+    -H 'Content-Type: application/json' -d '{}' 2>/dev/null)
+R2=$(curl -s -o /dev/null -w "%{http_code}" "http://$HOST:$HTTP_PORT/api/transactions/abc" 2>/dev/null)
+if [ "$R1" = "404" ] && [ "$R2" = "404" ]; then
+    echo -e "${GREEN}PASS${NC} (data-at-name=$R1, transactions=$R2)"
+    inc_pass
+else
+    echo -e "${RED}FAIL${NC} (data-at-name=$R1, transactions=$R2 — expected 404)"
+    inc_fail
+fi
+
+# ============================================
 # CRYPTO COMMANDS (offline, continued)
 # ============================================
 echo ""
@@ -517,11 +707,12 @@ echo -e "${BLUE}--- Streaming Commands ---${NC}"
 
 # watch-events: Watch real-time block events via WebSocket
 # Run for 10 seconds and check if it connects and receives events.
-# The node sends 9 event types: 3 block lifecycle, 4 genesis, 2 node lifecycle.
+# The node sends 10 event types: 3 block lifecycle, 1 transfer, 3 genesis, 2 node lifecycle.
 # Startup events (node-started, entered-running-state) are replayed from buffer.
+# Block events now include block number and timestamp.
 echo -n "Testing watch-events... "
 WB_START=$(date +%s.%N)
-run_with_timeout 10 cargo run -q --release -- watch-events -H $HOST --http-port $HTTP_PORT > "$OUTPUT" 2>&1 || true
+run_with_timeout 15 cargo run -q --release -- watch-events -H $HOST --http-port $HTTP_PORT > "$OUTPUT" 2>&1 || true
 WB_END=$(date +%s.%N)
 WB_MS=$(echo "($WB_END - $WB_START) * 1000" | bc | cut -d. -f1)
 save_log "watch-events"
@@ -531,25 +722,28 @@ if grep -q "Connected to node WebSocket" "$OUTPUT"; then
     HAS_FINALIZED=$(grep -c "Block Finalized" "$OUTPUT" 2>/dev/null | tr -d '\n' || echo 0)
     HAS_NODE_STARTED=$(grep -c "Node Started" "$OUTPUT" 2>/dev/null | tr -d '\n' || echo 0)
     HAS_RUNNING=$(grep -c "Entered Running State" "$OUTPUT" 2>/dev/null | tr -d '\n' || echo 0)
+    HAS_BLOCK_NUM=$(grep -c "Block #:" "$OUTPUT" 2>/dev/null | tr -d '\n' || echo 0)
     HAS_CREATED=${HAS_CREATED:-0}
     HAS_ADDED=${HAS_ADDED:-0}
     HAS_FINALIZED=${HAS_FINALIZED:-0}
     HAS_NODE_STARTED=${HAS_NODE_STARTED:-0}
     HAS_RUNNING=${HAS_RUNNING:-0}
+    HAS_BLOCK_NUM=${HAS_BLOCK_NUM:-0}
 
-    SUMMARY="created:$HAS_CREATED, added:$HAS_ADDED, finalized:$HAS_FINALIZED"
-    if [ "$HAS_NODE_STARTED" -gt 0 ] || [ "$HAS_RUNNING" -gt 0 ]; then
-        SUMMARY="$SUMMARY, node-started:$HAS_NODE_STARTED, running:$HAS_RUNNING"
-    fi
+    SUMMARY="created:$HAS_CREATED, added:$HAS_ADDED, finalized:$HAS_FINALIZED, node-started:$HAS_NODE_STARTED, running:$HAS_RUNNING"
 
-    if [ "$HAS_CREATED" -gt 0 ] && [ "$HAS_ADDED" -gt 0 ] && [ "$HAS_FINALIZED" -gt 0 ]; then
+    # Must receive at least block-created or block-added (heartbeat produces these).
+    # 15s window should be enough for at least one heartbeat cycle.
+    if [ "$HAS_CREATED" -eq 0 ] && [ "$HAS_ADDED" -eq 0 ]; then
+        echo -e "${RED}FAIL${NC} (no block events received in window) [$(format_duration $WB_MS)]"
+        echo "  Expected at least block-created or block-added. Got: $SUMMARY"
+        head -10 "$OUTPUT" | sed 's/^/    /'
+        inc_fail
+    elif [ "$HAS_CREATED" -gt 0 ] && [ "$HAS_ADDED" -gt 0 ] && [ "$HAS_FINALIZED" -gt 0 ]; then
         echo -e "${GREEN}PASS${NC} ($SUMMARY) [$(format_duration $WB_MS)]"
         inc_pass
-    elif [ "$HAS_CREATED" -gt 0 ] || [ "$HAS_ADDED" -gt 0 ] || [ "$HAS_FINALIZED" -gt 0 ]; then
-        echo -e "${YELLOW}PASS${NC} (partial: $SUMMARY) [$(format_duration $WB_MS)]"
-        inc_pass
     else
-        echo -e "${YELLOW}PASS${NC} (connected, no events in 10s - node may be idle) [$(format_duration $WB_MS)]"
+        echo -e "${GREEN}PASS${NC} (partial: $SUMMARY) [$(format_duration $WB_MS)]"
         inc_pass
     fi
 elif grep -qE "error|Error|refused|failed" "$OUTPUT"; then

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -509,15 +509,21 @@ elif [ -n "${TRANSFER_BLOCK_HASH:-}" ]; then
         inc_fail
     fi
 
-    # Verify transfers are null on validator (not readonly)
-    echo -n "Testing transfer-info (validator=null)... "
-    TV_RESP=$(curl -s "http://$HOST:$HTTP_PORT/api/block/$TRANSFER_BLOCK_HASH" 2>/dev/null)
-    if echo "$TV_RESP" | grep -q '"transfers":null' || ! echo "$TV_RESP" | grep -q '"fromAddr"'; then
-        echo -e "${GREEN}PASS${NC} (transfers null on validator)"
-        inc_pass
+    # Verify transfers are null on validator (not readonly).
+    # Only meaningful when validator and readonly are distinct nodes (shard).
+    # On standalone, the single node acts as both, so transfers are populated here too.
+    if [ "$HTTP_PORT" = "$OBSERVER_HTTP" ]; then
+        skip_test "transfer-info (validator=null)" "standalone (validator and readonly are the same node)"
     else
-        echo -e "${RED}FAIL${NC} (transfers should be null on validator)"
-        inc_fail
+        echo -n "Testing transfer-info (validator=null)... "
+        TV_RESP=$(curl -s "http://$HOST:$HTTP_PORT/api/block/$TRANSFER_BLOCK_HASH" 2>/dev/null)
+        if echo "$TV_RESP" | grep -q '"transfers":null' || ! echo "$TV_RESP" | grep -q '"fromAddr"'; then
+            echo -e "${GREEN}PASS${NC} (transfers null on validator)"
+            inc_pass
+        else
+            echo -e "${RED}FAIL${NC} (transfers should be null on validator)"
+            inc_fail
+        fi
     fi
 else
     skip_test "transfer-info (readonly)" "no block hash from transfer test"

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -348,7 +348,7 @@ echo -e "${BLUE}--- Node Inspection Commands (HTTP) ---${NC}"
 # status: Get node status and peer information
 run_test "status" \
     "cargo run -q --release -- status -H $HOST -p $HTTP_PORT" \
-    "Node status retrieved successfully|version"
+    "Node status retrieved successfully|Native Token:"
 
 # blocks: Get recent blocks
 run_test "blocks" \

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -515,29 +515,38 @@ fi
 echo ""
 echo -e "${BLUE}--- Streaming Commands ---${NC}"
 
-# watch-blocks: Watch real-time block events via WebSocket
-# Run for 10 seconds and check if it connects and receives all event types
-echo -n "Testing watch-blocks... "
+# watch-events: Watch real-time block events via WebSocket
+# Run for 10 seconds and check if it connects and receives events.
+# The node sends 9 event types: 3 block lifecycle, 4 genesis, 2 node lifecycle.
+# Startup events (node-started, entered-running-state) are replayed from buffer.
+echo -n "Testing watch-events... "
 WB_START=$(date +%s.%N)
-run_with_timeout 10 cargo run -q --release -- watch-blocks -H $HOST --http-port $HTTP_PORT > "$OUTPUT" 2>&1 || true
+run_with_timeout 10 cargo run -q --release -- watch-events -H $HOST --http-port $HTTP_PORT > "$OUTPUT" 2>&1 || true
 WB_END=$(date +%s.%N)
 WB_MS=$(echo "($WB_END - $WB_START) * 1000" | bc | cut -d. -f1)
-save_log "watch-blocks"
-# Check for successful connection and all three event types
+save_log "watch-events"
 if grep -q "Connected to node WebSocket" "$OUTPUT"; then
     HAS_CREATED=$(grep -c "Block Created" "$OUTPUT" 2>/dev/null | tr -d '\n' || echo 0)
     HAS_ADDED=$(grep -c "Block Added" "$OUTPUT" 2>/dev/null | tr -d '\n' || echo 0)
     HAS_FINALIZED=$(grep -c "Block Finalized" "$OUTPUT" 2>/dev/null | tr -d '\n' || echo 0)
-    # Ensure we have valid integers (default to 0 if empty)
+    HAS_NODE_STARTED=$(grep -c "Node Started" "$OUTPUT" 2>/dev/null | tr -d '\n' || echo 0)
+    HAS_RUNNING=$(grep -c "Entered Running State" "$OUTPUT" 2>/dev/null | tr -d '\n' || echo 0)
     HAS_CREATED=${HAS_CREATED:-0}
     HAS_ADDED=${HAS_ADDED:-0}
     HAS_FINALIZED=${HAS_FINALIZED:-0}
-    
+    HAS_NODE_STARTED=${HAS_NODE_STARTED:-0}
+    HAS_RUNNING=${HAS_RUNNING:-0}
+
+    SUMMARY="created:$HAS_CREATED, added:$HAS_ADDED, finalized:$HAS_FINALIZED"
+    if [ "$HAS_NODE_STARTED" -gt 0 ] || [ "$HAS_RUNNING" -gt 0 ]; then
+        SUMMARY="$SUMMARY, node-started:$HAS_NODE_STARTED, running:$HAS_RUNNING"
+    fi
+
     if [ "$HAS_CREATED" -gt 0 ] && [ "$HAS_ADDED" -gt 0 ] && [ "$HAS_FINALIZED" -gt 0 ]; then
-        echo -e "${GREEN}PASS${NC} (created:$HAS_CREATED, added:$HAS_ADDED, finalized:$HAS_FINALIZED) [$(format_duration $WB_MS)]"
+        echo -e "${GREEN}PASS${NC} ($SUMMARY) [$(format_duration $WB_MS)]"
         inc_pass
     elif [ "$HAS_CREATED" -gt 0 ] || [ "$HAS_ADDED" -gt 0 ] || [ "$HAS_FINALIZED" -gt 0 ]; then
-        echo -e "${YELLOW}PASS${NC} (partial: created:$HAS_CREATED, added:$HAS_ADDED, finalized:$HAS_FINALIZED) [$(format_duration $WB_MS)]"
+        echo -e "${YELLOW}PASS${NC} (partial: $SUMMARY) [$(format_duration $WB_MS)]"
         inc_pass
     else
         echo -e "${YELLOW}PASS${NC} (connected, no events in 10s - node may be idle) [$(format_duration $WB_MS)]"
@@ -548,7 +557,6 @@ elif grep -qE "error|Error|refused|failed" "$OUTPUT"; then
     head -5 "$OUTPUT" | sed 's/^/    /'
     inc_fail
 else
-    # No connection message - unexpected
     echo -e "${RED}FAIL${NC} (unexpected output) [$(format_duration $WB_MS)]"
     head -5 "$OUTPUT" | sed 's/^/    /'
     inc_fail

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -49,6 +49,19 @@ cd "$SCRIPT_DIR/.."
 echo "Building rust-client (release)..."
 cargo build --release
 
+# Detect node type from /api/status version. Tests that exercise Rust-only
+# features (new HTTP endpoints, view params, transfer extraction, enriched
+# WS events) are skipped when running against a Scala node.
+STATUS_JSON=$(curl -sf "http://$HOST:$HTTP_PORT/api/status" 2>/dev/null || echo '')
+if echo "$STATUS_JSON" | grep -q "F1r3node Rust"; then
+    NODE_TYPE=rust
+elif echo "$STATUS_JSON" | grep -q "F1r3node Scala"; then
+    NODE_TYPE=scala
+else
+    NODE_TYPE=unknown
+fi
+echo "Detected node type: $NODE_TYPE"
+
 # Log file for test outputs (single file per run)
 mkdir -p "logs"
 LOG_FILE="logs/smoke_test_$(date +%Y%m%d_%H%M%S).log"
@@ -457,8 +470,11 @@ else
 fi
 
 # transfer-info: Verify transfer data in block API on readonly
-# The readonly node extracts transfers via block replay (BlockReportAPI)
-if [ -n "${TRANSFER_BLOCK_HASH:-}" ]; then
+# The readonly node extracts transfers via block replay (BlockReportAPI) — Rust-only
+if [ "$NODE_TYPE" != "rust" ]; then
+    skip_test "transfer-info (readonly)" "rust-only (BlockReportAPI)"
+    skip_test "transfer-info (validator=null)" "rust-only (BlockReportAPI)"
+elif [ -n "${TRANSFER_BLOCK_HASH:-}" ]; then
     echo -n "Testing transfer-info (readonly)... "
     TI_START=$(date +%s.%N)
     # Poll readonly for transfers (block report may need a moment to warm cache)
@@ -509,6 +525,10 @@ else
 fi
 
 # transfers-available WS event: Connect to readonly WS, submit transfer, verify event
+# The TransfersAvailable event is Rust-only (emitted after block report cache warming)
+if [ "$NODE_TYPE" != "rust" ]; then
+    skip_test "transfers-available (WS)" "rust-only (TransfersAvailable event)"
+else
 echo -n "Testing transfers-available (WS)... "
 TA_START=$(date +%s.%N)
 # Start WS listener on readonly in background
@@ -536,6 +556,7 @@ else
     inc_fail
 fi
 rm -f "$TA_WS_OUT"
+fi  # NODE_TYPE = rust (transfers-available)
 
 # get-deploy: Get deploy execution details (cost, errored, blockNumber)
 # Uses deploy ID from deploy-and-wait (with data) test
@@ -581,10 +602,19 @@ run_test "network-consensus" \
     "Network consensus data retrieved successfully|Consensus Health"
 
 # ============================================
-# NEW HTTP ENDPOINT TESTS (direct curl)
+# NEW HTTP ENDPOINT TESTS (direct curl) — Rust-only
 # ============================================
 echo ""
 echo -e "${BLUE}--- New HTTP Endpoints ---${NC}"
+
+if [ "$NODE_TYPE" != "rust" ]; then
+    skip_test "/api/epoch" "rust-only endpoint"
+    skip_test "/api/validators" "rust-only endpoint"
+    skip_test "/api/bond-status" "rust-only endpoint"
+    skip_test "/api/estimate-cost" "rust-only endpoint"
+    skip_test "/api/deploy (summary view)" "rust-only (unified DeployResponse)"
+    skip_test "removed endpoints return 404" "rust-only (scala returns 400 for dead endpoints)"
+else
 
 # /api/epoch: Available on all node types (no exploratory deploy)
 echo -n "Testing /api/epoch... "
@@ -682,6 +712,8 @@ else
     echo -e "${RED}FAIL${NC} (data-at-name=$R1, transactions=$R2 — expected 404)"
     inc_fail
 fi
+
+fi  # NODE_TYPE = rust (New HTTP Endpoints)
 
 # ============================================
 # CRYPTO COMMANDS (offline, continued)

--- a/src/args.rs
+++ b/src/args.rs
@@ -106,8 +106,8 @@ pub enum Commands {
     /// Extract node ID from TLS private key file
     GetNodeId(GetNodeIdArgs),
 
-    /// Watch real-time block events via WebSocket
-    WatchBlocks(WatchBlocksArgs),
+    /// Watch real-time node events via WebSocket
+    WatchEvents(WatchEventsArgs),
 
     /// Interactive DAG visualization with real-time updates
     Dag(DagArgs),
@@ -781,9 +781,9 @@ pub struct GetNodeIdArgs {
     pub discovery_port: u16,
 }
 
-/// Arguments for watch-blocks command
+/// Arguments for watch-events command
 #[derive(Parser, Debug)]
-pub struct WatchBlocksArgs {
+pub struct WatchEventsArgs {
     /// Host address
     #[arg(short = 'H', long, default_value = "localhost")]
     pub host: String,
@@ -792,7 +792,7 @@ pub struct WatchBlocksArgs {
     #[arg(long, default_value_t = 40403)]
     pub http_port: u16,
 
-    /// Filter events by type: "created", "added", or "finalized"
+    /// Filter events by type: created, added, finalized, genesis, lifecycle
     #[arg(short, long)]
     pub filter: Option<String>,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -792,7 +792,7 @@ pub struct WatchEventsArgs {
     #[arg(long, default_value_t = 40403)]
     pub http_port: u16,
 
-    /// Filter events by type: created, added, finalized, genesis, lifecycle
+    /// Filter events by type: created, added, finalized (or finalised), transfers, genesis, lifecycle
     #[arg(short, long)]
     pub filter: Option<String>,
 

--- a/src/commands/dag.rs
+++ b/src/commands/dag.rs
@@ -110,7 +110,8 @@ fn parse_block_json(json: &serde_json::Value) -> Option<DagBlock> {
 
     let deploy_count = info.get("deployCount")?.as_i64().unwrap_or(0) as u32;
 
-    // Use isFinalized field if available, otherwise assume finalized for historical blocks
+    // Blocks missing isFinalized are skipped so the gap is visible rather than silently
+    // assumed finalized — aligns with no-swallow principle.
     let is_finalized = info.get("isFinalized").and_then(|v| v.as_bool())?;
     let status = if is_finalized {
         BlockStatus::Finalized

--- a/src/commands/dag.rs
+++ b/src/commands/dag.rs
@@ -316,9 +316,12 @@ fn parse_websocket_event(text: &str) -> Result<DagEvent, NodeCliError> {
                 }
             }
         }
-        "started" => {
-            // Initial connection event, ignore
-            return Err(NodeCliError::parse_error("Ignoring started event"));
+        // Non-block events: handshake, genesis ceremony, node lifecycle.
+        // Not relevant for DAG visualization.
+        "started" | "sent-unapproved-block" | "sent-approved-block"
+        | "block-approval-received" | "approved-block-received"
+        | "entered-running-state" | "node-started" => {
+            return Err(NodeCliError::parse_error("Non-block event, skipping"));
         }
         _ => {}
     }

--- a/src/commands/dag.rs
+++ b/src/commands/dag.rs
@@ -83,19 +83,22 @@ async fn fetch_initial_blocks(
     Ok(blocks)
 }
 
-/// Parse a block from JSON
+/// Parse a block from JSON. Handles both flat LightBlockInfo (legacy)
+/// and wrapped BlockInfoSerde format ({"blockInfo": {...}}).
 fn parse_block_json(json: &serde_json::Value) -> Option<DagBlock> {
-    let hash = json.get("blockHash")?.as_str()?.to_string();
-    let block_number = json.get("blockNumber")?.as_i64()?;
-    let timestamp_ms = json.get("timestamp")?.as_i64().unwrap_or(0);
+    // Unwrap blockInfo wrapper if present (new BlockInfoSerde format)
+    let info = json.get("blockInfo").unwrap_or(json);
+    let hash = info.get("blockHash")?.as_str()?.to_string();
+    let block_number = info.get("blockNumber")?.as_i64()?;
+    let timestamp_ms = info.get("timestamp")?.as_i64().unwrap_or(0);
     let timestamp = Utc
         .timestamp_millis_opt(timestamp_ms)
         .single()
         .unwrap_or_else(Utc::now);
-    let creator = json.get("sender")?.as_str()?.to_string();
-    let seq_num = json.get("seqNum")?.as_i64().unwrap_or(0);
+    let creator = info.get("sender")?.as_str()?.to_string();
+    let seq_num = info.get("seqNum")?.as_i64().unwrap_or(0);
 
-    let parents: Vec<String> = json
+    let parents: Vec<String> = info
         .get("parentsHashList")
         .and_then(|p| p.as_array())
         .map(|arr| {
@@ -105,10 +108,15 @@ fn parse_block_json(json: &serde_json::Value) -> Option<DagBlock> {
         })
         .unwrap_or_default();
 
-    let deploy_count = json.get("deployCount")?.as_i64().unwrap_or(0) as u32;
+    let deploy_count = info.get("deployCount")?.as_i64().unwrap_or(0) as u32;
 
-    // Assume finalized for historical blocks
-    let status = BlockStatus::Finalized;
+    // Use isFinalized field if available, otherwise assume finalized for historical blocks
+    let is_finalized = info.get("isFinalized").and_then(|v| v.as_bool())?;
+    let status = if is_finalized {
+        BlockStatus::Finalized
+    } else {
+        BlockStatus::Added
+    };
 
     let mut block = DagBlock::new(
         hash,
@@ -122,13 +130,13 @@ fn parse_block_json(json: &serde_json::Value) -> Option<DagBlock> {
     );
 
     // Optional fields
-    if let Some(shard) = json.get("shardId").and_then(|s| s.as_str()) {
+    if let Some(shard) = info.get("shardId").and_then(|s| s.as_str()) {
         block.shard_id = shard.to_string();
     }
-    if let Some(pre) = json.get("preStateHash").and_then(|s| s.as_str()) {
+    if let Some(pre) = info.get("preStateHash").and_then(|s| s.as_str()) {
         block.pre_state_hash = pre.to_string();
     }
-    if let Some(post) = json.get("postStateHash").and_then(|s| s.as_str()) {
+    if let Some(post) = info.get("postStateHash").and_then(|s| s.as_str()) {
         block.post_state_hash = post.to_string();
     }
 
@@ -158,19 +166,20 @@ async fn fetch_block_by_hash(api_base: &str, hash: &str) -> Option<DagBlock> {
     None
 }
 
-/// Parse a block from the /api/block/{hash} response format
-fn parse_block_info_json(json: &serde_json::Value) -> Option<DagBlock> {
-    let hash = json.get("blockHash")?.as_str()?.to_string();
-    let block_number = json.get("blockNumber")?.as_i64()?;
-    let timestamp_ms = json.get("timestamp")?.as_i64().unwrap_or(0);
+/// Parse a block from the /api/block/{hash} response format.
+/// Receives the inner blockInfo object (already unwrapped by caller).
+fn parse_block_info_json(info: &serde_json::Value) -> Option<DagBlock> {
+    let hash = info.get("blockHash")?.as_str()?.to_string();
+    let block_number = info.get("blockNumber")?.as_i64()?;
+    let timestamp_ms = info.get("timestamp")?.as_i64().unwrap_or(0);
     let timestamp = Utc
         .timestamp_millis_opt(timestamp_ms)
         .single()
         .unwrap_or_else(Utc::now);
-    let creator = json.get("sender")?.as_str()?.to_string();
-    let seq_num = json.get("seqNum")?.as_i64().unwrap_or(0);
+    let creator = info.get("sender")?.as_str()?.to_string();
+    let seq_num = info.get("seqNum")?.as_i64().unwrap_or(0);
 
-    let parents: Vec<String> = json
+    let parents: Vec<String> = info
         .get("parentsHashList")
         .and_then(|p| p.as_array())
         .map(|arr| {
@@ -180,10 +189,14 @@ fn parse_block_info_json(json: &serde_json::Value) -> Option<DagBlock> {
         })
         .unwrap_or_default();
 
-    let deploy_count = json.get("deployCount")?.as_i64().unwrap_or(0) as u32;
+    let deploy_count = info.get("deployCount")?.as_i64().unwrap_or(0) as u32;
 
-    // Assume finalized for fetched blocks
-    let status = BlockStatus::Finalized;
+    let is_finalized = info.get("isFinalized").and_then(|v| v.as_bool())?;
+    let status = if is_finalized {
+        BlockStatus::Finalized
+    } else {
+        BlockStatus::Added
+    };
 
     let mut block = DagBlock::new(
         hash,
@@ -197,13 +210,13 @@ fn parse_block_info_json(json: &serde_json::Value) -> Option<DagBlock> {
     );
 
     // Optional fields
-    if let Some(shard) = json.get("shardId").and_then(|s| s.as_str()) {
+    if let Some(shard) = info.get("shardId").and_then(|s| s.as_str()) {
         block.shard_id = shard.to_string();
     }
-    if let Some(pre) = json.get("preStateHash").and_then(|s| s.as_str()) {
+    if let Some(pre) = info.get("preStateHash").and_then(|s| s.as_str()) {
         block.pre_state_hash = pre.to_string();
     }
-    if let Some(post) = json.get("postStateHash").and_then(|s| s.as_str()) {
+    if let Some(post) = info.get("postStateHash").and_then(|s| s.as_str()) {
         block.post_state_hash = post.to_string();
     }
 

--- a/src/commands/dag.rs
+++ b/src/commands/dag.rs
@@ -331,9 +331,13 @@ fn parse_websocket_event(text: &str) -> Result<DagEvent, NodeCliError> {
         }
         // Non-block events: handshake, genesis ceremony, node lifecycle.
         // Not relevant for DAG visualization.
-        "started" | "sent-unapproved-block" | "sent-approved-block"
-        | "block-approval-received" | "approved-block-received"
-        | "entered-running-state" | "node-started" => {
+        "started"
+        | "sent-unapproved-block"
+        | "sent-approved-block"
+        | "block-approval-received"
+        | "approved-block-received"
+        | "entered-running-state"
+        | "node-started" => {
             return Err(NodeCliError::parse_error("Non-block event, skipping"));
         }
         _ => {}

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -6,10 +6,11 @@ use tokio_tungstenite::{connect_async, tungstenite::Message};
 
 /// F1R3FLY node event from WebSocket /ws/events endpoint.
 ///
-/// The node defines 9 event types in F1r3flyEvent:
+/// The node defines 10 event types in F1r3flyEvent:
 ///   Block lifecycle:  block-created, block-added, block-finalised
+///   Transfer:         transfers-available (readonly only, after block report)
 ///   Genesis ceremony: sent-unapproved-block, sent-approved-block,
-///                     block-approval-received, approved-block-received
+///                     approved-block-received
 ///   Node lifecycle:   entered-running-state, node-started
 ///
 /// The "started" variant is a WebSocket handshake (not an F1r3flyEvent).
@@ -36,7 +37,13 @@ pub enum NodeEvent {
     BlockFinalised {
         #[serde(rename = "schema-version")]
         schema_version: i32,
-        payload: FinalizedBlockPayload,
+        payload: BlockEventPayload,
+    },
+    // Transfer extraction (readonly only)
+    TransfersAvailable {
+        #[serde(rename = "schema-version")]
+        schema_version: i32,
+        payload: TransfersAvailablePayload,
     },
     // Genesis ceremony
     SentUnapprovedBlock {
@@ -48,11 +55,6 @@ pub enum NodeEvent {
         #[serde(rename = "schema-version")]
         schema_version: i32,
         payload: BlockHashPayload,
-    },
-    BlockApprovalReceived {
-        #[serde(rename = "schema-version")]
-        schema_version: i32,
-        payload: ApprovalPayload,
     },
     ApprovedBlockReceived {
         #[serde(rename = "schema-version")]
@@ -76,6 +78,8 @@ pub enum NodeEvent {
 #[serde(rename_all = "kebab-case")]
 pub struct BlockEventPayload {
     pub block_hash: String,
+    pub block_number: i64,
+    pub timestamp: i64,
     pub parent_hashes: Vec<String>,
     pub justification_hashes: Vec<(String, String)>,
     pub deploys: Vec<BlockEventDeploy>,
@@ -94,26 +98,32 @@ pub struct BlockEventDeploy {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub struct FinalizedBlockPayload {
+pub struct TransfersAvailablePayload {
     pub block_hash: String,
-    pub parent_hashes: Vec<String>,
-    pub justification_hashes: Vec<(String, String)>,
-    pub deploys: Vec<BlockEventDeploy>,
-    pub creator: String,
-    pub seq_num: i32,
+    pub block_number: i64,
+    pub deploys: Vec<DeployTransfers>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeployTransfers {
+    pub deploy_id: String,
+    pub transfers: Vec<TransferEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct TransferEvent {
+    pub from_addr: String,
+    pub to_addr: String,
+    pub amount: i64,
+    pub success: bool,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct BlockHashPayload {
     pub block_hash: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub struct ApprovalPayload {
-    pub block_hash: String,
-    pub sender: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -127,6 +137,7 @@ struct EventStats {
     created: u32,
     added: u32,
     finalized: u32,
+    transfers: u32,
     genesis: u32,
     lifecycle: u32,
     total: u32,
@@ -138,6 +149,7 @@ impl EventStats {
             created: 0,
             added: 0,
             finalized: 0,
+            transfers: 0,
             genesis: 0,
             lifecycle: 0,
             total: 0,
@@ -150,9 +162,9 @@ impl EventStats {
             NodeEvent::BlockCreated { .. } => self.created += 1,
             NodeEvent::BlockAdded { .. } => self.added += 1,
             NodeEvent::BlockFinalised { .. } => self.finalized += 1,
+            NodeEvent::TransfersAvailable { .. } => self.transfers += 1,
             NodeEvent::SentUnapprovedBlock { .. }
             | NodeEvent::SentApprovedBlock { .. }
-            | NodeEvent::BlockApprovalReceived { .. }
             | NodeEvent::ApprovedBlockReceived { .. } => self.genesis += 1,
             NodeEvent::EnteredRunningState { .. }
             | NodeEvent::NodeStarted { .. } => self.lifecycle += 1,
@@ -166,6 +178,9 @@ impl EventStats {
         println!(" - Created:    {}", self.created);
         println!(" - Added:      {}", self.added);
         println!(" - Finalized:  {}", self.finalized);
+        if self.transfers > 0 {
+            println!(" - Transfers:  {}", self.transfers);
+        }
         if self.genesis > 0 {
             println!(" - Genesis:    {}", self.genesis);
         }
@@ -293,9 +308,9 @@ fn handle_event(text: &str, args: &WatchEventsArgs, stats: &mut EventStats) -> R
             (NodeEvent::BlockCreated { .. }, "created") => true,
             (NodeEvent::BlockAdded { .. }, "added") => true,
             (NodeEvent::BlockFinalised { .. }, "finalized" | "finalised") => true,
+            (NodeEvent::TransfersAvailable { .. }, "transfers") => true,
             (NodeEvent::SentUnapprovedBlock { .. }, "genesis") => true,
             (NodeEvent::SentApprovedBlock { .. }, "genesis") => true,
-            (NodeEvent::BlockApprovalReceived { .. }, "genesis") => true,
             (NodeEvent::ApprovedBlockReceived { .. }, "genesis") => true,
             (NodeEvent::EnteredRunningState { .. }, "lifecycle") => true,
             (NodeEvent::NodeStarted { .. }, "lifecycle") => true,
@@ -327,18 +342,22 @@ fn display_pretty(event: &NodeEvent) {
         }
         NodeEvent::BlockFinalised { payload, .. } => {
             println!(" Block Finalized");
-            println!(" Hash:     {}", payload.block_hash);
-            println!(" Creator:  {}", payload.creator);
-            println!(" Seq Num:  {}", payload.seq_num);
-            println!(" Parents:  {}", payload.parent_hashes.len());
-            if !payload.deploys.is_empty() {
-                println!(
-                    " Deploys:  {} [{}]",
-                    payload.deploys.len(),
-                    payload.deploys.iter().map(|d| d.id.clone()).collect::<Vec<_>>().join(", ")
-                );
-            } else {
-                println!(" Deploys:  {}", payload.deploys.len());
+            display_block_payload(payload);
+        }
+        NodeEvent::TransfersAvailable { payload, .. } => {
+            println!(" Transfers Available");
+            println!(" Block:    {} (#{}))", payload.block_hash, payload.block_number);
+            println!(" Deploys:  {}", payload.deploys.len());
+            for dt in &payload.deploys {
+                println!("   Deploy: {}  ({} transfers)", &dt.deploy_id[..24.min(dt.deploy_id.len())], dt.transfers.len());
+                for t in &dt.transfers {
+                    println!("     {} -> {} : {} ({})",
+                        &t.from_addr[..16.min(t.from_addr.len())],
+                        &t.to_addr[..16.min(t.to_addr.len())],
+                        t.amount,
+                        if t.success { "ok" } else { "failed" },
+                    );
+                }
             }
             println!();
         }
@@ -350,12 +369,6 @@ fn display_pretty(event: &NodeEvent) {
         NodeEvent::SentApprovedBlock { payload, .. } => {
             println!(" Sent Approved Block");
             println!(" Hash: {}", payload.block_hash);
-            println!();
-        }
-        NodeEvent::BlockApprovalReceived { payload, .. } => {
-            println!(" Block Approval Received");
-            println!(" Hash:   {}", payload.block_hash);
-            println!(" Sender: {}", payload.sender);
             println!();
         }
         NodeEvent::ApprovedBlockReceived { payload, .. } => {
@@ -378,6 +391,8 @@ fn display_pretty(event: &NodeEvent) {
 
 fn display_block_payload(payload: &BlockEventPayload) {
     println!(" Hash:     {}", payload.block_hash);
+    println!(" Block #:  {}", payload.block_number);
+    println!(" Time:     {}", payload.timestamp);
     println!(" Creator:  {}", payload.creator);
     println!(" Seq Num:  {}", payload.seq_num);
     println!(" Parents:  {}", payload.parent_hashes.len());

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -78,8 +78,10 @@ pub enum NodeEvent {
 #[serde(rename_all = "kebab-case")]
 pub struct BlockEventPayload {
     pub block_hash: String,
-    pub block_number: i64,
-    pub timestamp: i64,
+    #[serde(default)]
+    pub block_number: Option<i64>,
+    #[serde(default)]
+    pub timestamp: Option<i64>,
     pub parent_hashes: Vec<String>,
     pub justification_hashes: Vec<(String, String)>,
     pub deploys: Vec<BlockEventDeploy>,
@@ -400,8 +402,20 @@ fn display_pretty(event: &NodeEvent) {
 
 fn display_block_payload(payload: &BlockEventPayload) {
     println!(" Hash:     {}", payload.block_hash);
-    println!(" Block #:  {}", payload.block_number);
-    println!(" Time:     {}", payload.timestamp);
+    println!(
+        " Block #:  {}",
+        payload
+            .block_number
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "-".to_string())
+    );
+    println!(
+        " Time:     {}",
+        payload
+            .timestamp
+            .map(|t| t.to_string())
+            .unwrap_or_else(|| "-".to_string())
+    );
     println!(" Creator:  {}", payload.creator);
     println!(" Seq Num:  {}", payload.seq_num);
     println!(" Parents:  {}", payload.parent_hashes.len());

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -166,8 +166,9 @@ impl EventStats {
             NodeEvent::SentUnapprovedBlock { .. }
             | NodeEvent::SentApprovedBlock { .. }
             | NodeEvent::ApprovedBlockReceived { .. } => self.genesis += 1,
-            NodeEvent::EnteredRunningState { .. }
-            | NodeEvent::NodeStarted { .. } => self.lifecycle += 1,
+            NodeEvent::EnteredRunningState { .. } | NodeEvent::NodeStarted { .. } => {
+                self.lifecycle += 1
+            }
             NodeEvent::Started { .. } => {}
         }
     }
@@ -346,12 +347,20 @@ fn display_pretty(event: &NodeEvent) {
         }
         NodeEvent::TransfersAvailable { payload, .. } => {
             println!(" Transfers Available");
-            println!(" Block:    {} (#{}))", payload.block_hash, payload.block_number);
+            println!(
+                " Block:    {} (#{}))",
+                payload.block_hash, payload.block_number
+            );
             println!(" Deploys:  {}", payload.deploys.len());
             for dt in &payload.deploys {
-                println!("   Deploy: {}  ({} transfers)", &dt.deploy_id[..24.min(dt.deploy_id.len())], dt.transfers.len());
+                println!(
+                    "   Deploy: {}  ({} transfers)",
+                    &dt.deploy_id[..24.min(dt.deploy_id.len())],
+                    dt.transfers.len()
+                );
                 for t in &dt.transfers {
-                    println!("     {} -> {} : {} ({})",
+                    println!(
+                        "     {} -> {} : {} ({})",
                         &t.from_addr[..16.min(t.from_addr.len())],
                         &t.to_addr[..16.min(t.to_addr.len())],
                         t.amount,
@@ -400,7 +409,12 @@ fn display_block_payload(payload: &BlockEventPayload) {
         println!(
             " Deploys:  {} [{}]",
             payload.deploys.len(),
-            payload.deploys.iter().map(|d| d.id.clone()).collect::<Vec<_>>().join(", ")
+            payload
+                .deploys
+                .iter()
+                .map(|d| d.id.clone())
+                .collect::<Vec<_>>()
+                .join(", ")
         );
     } else {
         println!(" Deploys:  {}", payload.deploys.len());

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -1,18 +1,28 @@
-use crate::args::WatchBlocksArgs;
+use crate::args::WatchEventsArgs;
 use crate::error::{NodeCliError, Result};
 use futures_util::StreamExt;
 use serde::Deserialize;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
-/// RChain blockchain event from WebSocket
+/// F1R3FLY node event from WebSocket /ws/events endpoint.
+///
+/// The node defines 9 event types in F1r3flyEvent:
+///   Block lifecycle:  block-created, block-added, block-finalised
+///   Genesis ceremony: sent-unapproved-block, sent-approved-block,
+///                     block-approval-received, approved-block-received
+///   Node lifecycle:   entered-running-state, node-started
+///
+/// The "started" variant is a WebSocket handshake (not an F1r3flyEvent).
 #[derive(Debug, Deserialize)]
 #[serde(tag = "event")]
 #[serde(rename_all = "kebab-case")]
-pub enum RChainEvent {
+pub enum NodeEvent {
+    // WebSocket handshake
     Started {
         #[serde(rename = "schema-version")]
         schema_version: i32,
     },
+    // Block lifecycle
     BlockCreated {
         #[serde(rename = "schema-version")]
         schema_version: i32,
@@ -27,6 +37,38 @@ pub enum RChainEvent {
         #[serde(rename = "schema-version")]
         schema_version: i32,
         payload: FinalizedBlockPayload,
+    },
+    // Genesis ceremony
+    SentUnapprovedBlock {
+        #[serde(rename = "schema-version")]
+        schema_version: i32,
+        payload: BlockHashPayload,
+    },
+    SentApprovedBlock {
+        #[serde(rename = "schema-version")]
+        schema_version: i32,
+        payload: BlockHashPayload,
+    },
+    BlockApprovalReceived {
+        #[serde(rename = "schema-version")]
+        schema_version: i32,
+        payload: ApprovalPayload,
+    },
+    ApprovedBlockReceived {
+        #[serde(rename = "schema-version")]
+        schema_version: i32,
+        payload: BlockHashPayload,
+    },
+    // Node lifecycle
+    EnteredRunningState {
+        #[serde(rename = "schema-version")]
+        schema_version: i32,
+        payload: BlockHashPayload,
+    },
+    NodeStarted {
+        #[serde(rename = "schema-version")]
+        schema_version: i32,
+        payload: NodeStartedPayload,
     },
 }
 
@@ -54,6 +96,30 @@ pub struct BlockEventDeploy {
 #[serde(rename_all = "kebab-case")]
 pub struct FinalizedBlockPayload {
     pub block_hash: String,
+    pub parent_hashes: Vec<String>,
+    pub justification_hashes: Vec<(String, String)>,
+    pub deploys: Vec<BlockEventDeploy>,
+    pub creator: String,
+    pub seq_num: i32,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct BlockHashPayload {
+    pub block_hash: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ApprovalPayload {
+    pub block_hash: String,
+    pub sender: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct NodeStartedPayload {
+    pub address: String,
 }
 
 /// Statistics for the watch session
@@ -61,6 +127,8 @@ struct EventStats {
     created: u32,
     added: u32,
     finalized: u32,
+    genesis: u32,
+    lifecycle: u32,
     total: u32,
 }
 
@@ -70,36 +138,50 @@ impl EventStats {
             created: 0,
             added: 0,
             finalized: 0,
+            genesis: 0,
+            lifecycle: 0,
             total: 0,
         }
     }
 
-    fn increment(&mut self, event: &RChainEvent) {
+    fn increment(&mut self, event: &NodeEvent) {
         self.total += 1;
         match event {
-            RChainEvent::BlockCreated { .. } => self.created += 1,
-            RChainEvent::BlockAdded { .. } => self.added += 1,
-            RChainEvent::BlockFinalised { .. } => self.finalized += 1,
-            RChainEvent::Started { .. } => {}
+            NodeEvent::BlockCreated { .. } => self.created += 1,
+            NodeEvent::BlockAdded { .. } => self.added += 1,
+            NodeEvent::BlockFinalised { .. } => self.finalized += 1,
+            NodeEvent::SentUnapprovedBlock { .. }
+            | NodeEvent::SentApprovedBlock { .. }
+            | NodeEvent::BlockApprovalReceived { .. }
+            | NodeEvent::ApprovedBlockReceived { .. } => self.genesis += 1,
+            NodeEvent::EnteredRunningState { .. }
+            | NodeEvent::NodeStarted { .. } => self.lifecycle += 1,
+            NodeEvent::Started { .. } => {}
         }
     }
 
     fn print_summary(&self, duration: std::time::Duration) {
         println!("\n Event Statistics:");
         println!(" Total Events: {}", self.total);
-        println!(" - Created: {}", self.created);
-        println!(" - Added: {}", self.added);
-        println!(" - Finalized: {}", self.finalized);
-        println!(" Duration: {:.1}s", duration.as_secs_f64());
+        println!(" - Created:    {}", self.created);
+        println!(" - Added:      {}", self.added);
+        println!(" - Finalized:  {}", self.finalized);
+        if self.genesis > 0 {
+            println!(" - Genesis:    {}", self.genesis);
+        }
+        if self.lifecycle > 0 {
+            println!(" - Lifecycle:  {}", self.lifecycle);
+        }
+        println!(" Duration:     {:.1}s", duration.as_secs_f64());
         if duration.as_secs() > 0 {
             let rate = self.total as f64 / duration.as_secs_f64();
-            println!(" Rate: {:.2} events/sec", rate);
+            println!(" Rate:         {:.2} events/sec", rate);
         }
     }
 }
 
 /// Watch blocks command - connects to WebSocket and streams block events
-pub async fn watch_blocks_command(args: &WatchBlocksArgs) -> Result<()> {
+pub async fn watch_events_command(args: &WatchEventsArgs) -> Result<()> {
     let ws_url = format!("ws://{}:{}/ws/events", args.host, args.http_port);
 
     println!(" Connecting to F1r3fly node WebSocket...");
@@ -119,13 +201,11 @@ pub async fn watch_blocks_command(args: &WatchBlocksArgs) -> Result<()> {
     loop {
         match connect_and_watch(&ws_url, args, &mut stats).await {
             Ok(_) => {
-                // Normal exit
                 break;
             }
             Err(e) => {
                 retry_count += 1;
 
-                // Check if we should stop retrying
                 if !args.retry_forever && retry_count > MAX_RETRIES {
                     println!(" Max reconnection attempts ({}) reached", MAX_RETRIES);
                     return Err(e);
@@ -159,7 +239,7 @@ pub async fn watch_blocks_command(args: &WatchBlocksArgs) -> Result<()> {
 
 async fn connect_and_watch(
     ws_url: &str,
-    args: &WatchBlocksArgs,
+    args: &WatchEventsArgs,
     stats: &mut EventStats,
 ) -> Result<()> {
     let (ws_stream, _) = connect_async(ws_url).await.map_err(|e| {
@@ -171,7 +251,6 @@ async fn connect_and_watch(
 
     let (mut _write, mut read) = ws_stream.split();
 
-    // Set up Ctrl+C handler
     let ctrl_c = tokio::signal::ctrl_c();
     tokio::pin!(ctrl_c);
 
@@ -205,16 +284,21 @@ async fn connect_and_watch(
     }
 }
 
-fn handle_event(text: &str, args: &WatchBlocksArgs, stats: &mut EventStats) -> Result<()> {
-    let event: RChainEvent = serde_json::from_str(text)
+fn handle_event(text: &str, args: &WatchEventsArgs, stats: &mut EventStats) -> Result<()> {
+    let event: NodeEvent = serde_json::from_str(text)
         .map_err(|e| NodeCliError::from(format!("Failed to parse event: {}", e)))?;
 
-    // Apply filter
     if let Some(filter) = &args.filter {
         let matches = match (&event, filter.as_str()) {
-            (RChainEvent::BlockCreated { .. }, "created") => true,
-            (RChainEvent::BlockAdded { .. }, "added") => true,
-            (RChainEvent::BlockFinalised { .. }, "finalized" | "finalised") => true,
+            (NodeEvent::BlockCreated { .. }, "created") => true,
+            (NodeEvent::BlockAdded { .. }, "added") => true,
+            (NodeEvent::BlockFinalised { .. }, "finalized" | "finalised") => true,
+            (NodeEvent::SentUnapprovedBlock { .. }, "genesis") => true,
+            (NodeEvent::SentApprovedBlock { .. }, "genesis") => true,
+            (NodeEvent::BlockApprovalReceived { .. }, "genesis") => true,
+            (NodeEvent::ApprovedBlockReceived { .. }, "genesis") => true,
+            (NodeEvent::EnteredRunningState { .. }, "lifecycle") => true,
+            (NodeEvent::NodeStarted { .. }, "lifecycle") => true,
             _ => false,
         };
 
@@ -224,68 +308,87 @@ fn handle_event(text: &str, args: &WatchBlocksArgs, stats: &mut EventStats) -> R
     }
 
     stats.increment(&event);
-
-    // Display in pretty format with deploys shown
     display_pretty(&event);
-
     Ok(())
 }
 
-fn display_pretty(event: &RChainEvent) {
+fn display_pretty(event: &NodeEvent) {
     match event {
-        RChainEvent::Started { .. } => {
+        NodeEvent::Started { .. } => {
             println!(" WebSocket connection started\n");
         }
-        RChainEvent::BlockCreated { payload, .. } => {
+        NodeEvent::BlockCreated { payload, .. } => {
             println!(" Block Created");
-            println!(" Hash: {}", payload.block_hash);
-            println!(" Creator: {}", payload.creator);
-            println!(" Seq Num: {}", payload.seq_num);
-            println!(" Parents: {}", payload.parent_hashes.len());
-
-            if !payload.deploys.is_empty() {
-                println!(
-                    " Deploys: {} [{}]",
-                    payload.deploys.len(),
-                    payload
-                        .deploys
-                        .iter()
-                        .map(|d| d.id.clone())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
-            } else {
-                println!(" Deploys: {}", payload.deploys.len());
-            }
-            println!();
+            display_block_payload(payload);
         }
-        RChainEvent::BlockAdded { payload, .. } => {
+        NodeEvent::BlockAdded { payload, .. } => {
             println!(" Block Added");
-            println!(" Hash: {}", payload.block_hash);
-            println!(" Creator: {}", payload.creator);
-            println!(" Seq Num: {}", payload.seq_num);
-            println!(" Parents: {}", payload.parent_hashes.len());
-
+            display_block_payload(payload);
+        }
+        NodeEvent::BlockFinalised { payload, .. } => {
+            println!(" Block Finalized");
+            println!(" Hash:     {}", payload.block_hash);
+            println!(" Creator:  {}", payload.creator);
+            println!(" Seq Num:  {}", payload.seq_num);
+            println!(" Parents:  {}", payload.parent_hashes.len());
             if !payload.deploys.is_empty() {
                 println!(
-                    " Deploys: {} [{}]",
+                    " Deploys:  {} [{}]",
                     payload.deploys.len(),
-                    payload
-                        .deploys
-                        .iter()
-                        .map(|d| d.id.clone())
-                        .collect::<Vec<_>>()
-                        .join(", ")
+                    payload.deploys.iter().map(|d| d.id.clone()).collect::<Vec<_>>().join(", ")
                 );
             } else {
-                println!(" Deploys: {}", payload.deploys.len());
+                println!(" Deploys:  {}", payload.deploys.len());
             }
             println!();
         }
-        RChainEvent::BlockFinalised { payload, .. } => {
-            println!(" Block Finalized");
+        NodeEvent::SentUnapprovedBlock { payload, .. } => {
+            println!(" Sent Unapproved Block");
             println!(" Hash: {}", payload.block_hash);
+            println!();
+        }
+        NodeEvent::SentApprovedBlock { payload, .. } => {
+            println!(" Sent Approved Block");
+            println!(" Hash: {}", payload.block_hash);
+            println!();
+        }
+        NodeEvent::BlockApprovalReceived { payload, .. } => {
+            println!(" Block Approval Received");
+            println!(" Hash:   {}", payload.block_hash);
+            println!(" Sender: {}", payload.sender);
+            println!();
+        }
+        NodeEvent::ApprovedBlockReceived { payload, .. } => {
+            println!(" Approved Block Received");
+            println!(" Hash: {}", payload.block_hash);
+            println!();
+        }
+        NodeEvent::EnteredRunningState { payload, .. } => {
+            println!(" Entered Running State");
+            println!(" Block: {}", payload.block_hash);
+            println!();
+        }
+        NodeEvent::NodeStarted { payload, .. } => {
+            println!(" Node Started");
+            println!(" Address: {}", payload.address);
             println!();
         }
     }
+}
+
+fn display_block_payload(payload: &BlockEventPayload) {
+    println!(" Hash:     {}", payload.block_hash);
+    println!(" Creator:  {}", payload.creator);
+    println!(" Seq Num:  {}", payload.seq_num);
+    println!(" Parents:  {}", payload.parent_hashes.len());
+    if !payload.deploys.is_empty() {
+        println!(
+            " Deploys:  {} [{}]",
+            payload.deploys.len(),
+            payload.deploys.iter().map(|d| d.id.clone()).collect::<Vec<_>>().join(", ")
+        );
+    } else {
+        println!(" Deploys:  {}", payload.deploys.len());
+    }
+    println!();
 }

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -200,6 +200,25 @@ impl EventStats {
 
 /// Watch blocks command - connects to WebSocket and streams block events
 pub async fn watch_events_command(args: &WatchEventsArgs) -> Result<()> {
+    const VALID_FILTERS: &[&str] = &[
+        "created",
+        "added",
+        "finalized",
+        "finalised",
+        "transfers",
+        "genesis",
+        "lifecycle",
+    ];
+    if let Some(filter) = &args.filter {
+        if !VALID_FILTERS.contains(&filter.as_str()) {
+            return Err(NodeCliError::from(format!(
+                "Invalid --filter value '{}'. Valid values: {}",
+                filter,
+                VALID_FILTERS.join(", ")
+            )));
+        }
+    }
+
     let ws_url = format!("ws://{}:{}/ws/events", args.host, args.http_port);
 
     println!(" Connecting to F1r3fly node WebSocket...");

--- a/src/commands/network.rs
+++ b/src/commands/network.rs
@@ -53,7 +53,7 @@ fn config_from_transfer_args(args: &TransferArgs) -> ConnectionConfig {
         args.http_port,
         &args.private_key,
         args.max_wait,
-        30,
+        args.max_wait, // Use max_wait for finalization too (no separate arg)
         args.check_interval,
         args.observer_host.as_deref(),
         args.observer_port,
@@ -67,7 +67,7 @@ fn config_from_bond_args(args: &BondValidatorArgs) -> ConnectionConfig {
         args.http_port,
         &args.private_key,
         args.max_wait,
-        30,
+        args.max_wait, // Use max_wait for finalization too (no separate arg)
         args.check_interval,
         args.observer_host.as_deref(),
         args.observer_port,
@@ -542,22 +542,34 @@ pub async fn get_deploy_command(args: &GetDeployArgs) -> Result<(), Box<dyn std:
             _ => {
                 println!("Deploy Information");
                 println!("----------------------------------------");
-                println!("Deploy ID:    {}", args.deploy_id);
+                println!("Deploy ID:    {}", detail.deploy_id);
                 println!("Block Hash:   {}", detail.block_hash);
                 println!("Block Number: {}", detail.block_number);
-                println!("Deployer:     {}", detail.deployer);
+                println!("Finalized:    {}", detail.is_finalized);
+                if let Some(ref deployer) = detail.deployer {
+                    println!("Deployer:     {}", deployer);
+                }
                 println!("Cost:         {}", detail.cost);
                 println!("Errored:      {}", detail.errored);
-                if !detail.system_deploy_error.is_empty() {
-                    println!("Error:        {}", detail.system_deploy_error);
+                if let Some(ref err) = detail.system_deploy_error {
+                    if !err.is_empty() {
+                        println!("Error:        {}", err);
+                    }
                 }
-                println!("Phlo Price:   {}", detail.phlo_price);
-                println!("Phlo Limit:   {}", detail.phlo_limit);
+                if let Some(price) = detail.phlo_price {
+                    println!("Phlo Price:   {}", price);
+                }
+                if let Some(limit) = detail.phlo_limit {
+                    println!("Phlo Limit:   {}", limit);
+                }
                 println!("Timestamp:    {}", detail.timestamp);
-                println!("Sig Algo:     {}", detail.sig_algorithm);
+                if let Some(ref algo) = detail.sig_algorithm {
+                    println!("Sig Algo:     {}", algo);
+                }
                 if args.verbose {
-                    println!("Signature:    {}", detail.sig);
-                    println!("VABN:         {}", detail.valid_after_block_number);
+                    if let Some(vabn) = detail.valid_after_block_number {
+                        println!("VABN:         {}", vabn);
+                    }
                 }
                 println!("Query time:   {:.2?}", duration);
             }

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 pub async fn status_command(args: &HttpArgs) -> Result<(), Box<dyn std::error::Error>> {
     println!(" Getting node status from {}:{}", args.host, args.port);
 
-    let url = format!("http://{}:{}/status", args.host, args.port);
+    let url = format!("http://{}:{}/api/status", args.host, args.port);
     let client = reqwest::Client::new();
 
     let start_time = Instant::now();
@@ -18,12 +18,25 @@ pub async fn status_command(args: &HttpArgs) -> Result<(), Box<dyn std::error::E
             let duration = start_time.elapsed();
             if response.status().is_success() {
                 let status_text = response.text().await?;
-                let status_json: serde_json::Value = serde_json::from_str(&status_text)?;
+                let status: crate::f1r3fly_api::NodeStatus =
+                    serde_json::from_str(&status_text)?;
 
                 println!(" Node status retrieved successfully!");
                 println!(" Time taken: {:.2?}", duration);
-                println!(" Node Status:");
-                println!("{}", serde_json::to_string_pretty(&status_json)?);
+                println!();
+                println!("  Address:       {}", status.address);
+                println!("  Network:       {}", status.network_id);
+                println!("  Shard:         {}", status.shard_id);
+                println!("  Peers:         {}", status.peers);
+                println!("  Nodes:         {}", status.nodes);
+                println!("  Min Phlo:      {}", status.min_phlo_price);
+                println!(
+                    "  Native Token:  {} ({}, {} decimals)",
+                    status.native_token_name,
+                    status.native_token_symbol,
+                    status.native_token_decimals
+                );
+                println!("  Version:       {}", status.version);
             } else {
                 println!(" Failed to get node status: HTTP {}", response.status());
                 println!("Error: {}", response.text().await?);

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -29,12 +29,14 @@ pub async fn status_command(args: &HttpArgs) -> Result<(), Box<dyn std::error::E
                 println!("  Peers:         {}", status.peers);
                 println!("  Nodes:         {}", status.nodes);
                 println!("  Min Phlo:      {}", status.min_phlo_price);
-                println!(
-                    "  Native Token:  {} ({}, {} decimals)",
-                    status.native_token_name,
-                    status.native_token_symbol,
-                    status.native_token_decimals
-                );
+                if !status.native_token_name.is_empty() {
+                    println!(
+                        "  Native Token:  {} ({}, {} decimals)",
+                        status.native_token_name,
+                        status.native_token_symbol,
+                        status.native_token_decimals
+                    );
+                }
                 println!("  LFB Number:    {}", status.last_finalized_block_number);
                 println!("  Validator:     {}", status.is_validator);
                 println!("  Read Only:     {}", status.is_read_only);

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -36,6 +36,11 @@ pub async fn status_command(args: &HttpArgs) -> Result<(), Box<dyn std::error::E
                     status.native_token_symbol,
                     status.native_token_decimals
                 );
+                println!("  LFB Number:    {}", status.last_finalized_block_number);
+                println!("  Validator:     {}", status.is_validator);
+                println!("  Read Only:     {}", status.is_read_only);
+                println!("  Ready:         {}", status.is_ready);
+                println!("  Epoch:         {} (length: {})", status.current_epoch, status.epoch_length);
                 println!("  Version:       {}", status.version);
             } else {
                 println!(" Failed to get node status: HTTP {}", response.status());

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -18,8 +18,7 @@ pub async fn status_command(args: &HttpArgs) -> Result<(), Box<dyn std::error::E
             let duration = start_time.elapsed();
             if response.status().is_success() {
                 let status_text = response.text().await?;
-                let status: crate::f1r3fly_api::NodeStatus =
-                    serde_json::from_str(&status_text)?;
+                let status: crate::f1r3fly_api::NodeStatus = serde_json::from_str(&status_text)?;
 
                 println!(" Node status retrieved successfully!");
                 println!(" Time taken: {:.2?}", duration);
@@ -40,7 +39,10 @@ pub async fn status_command(args: &HttpArgs) -> Result<(), Box<dyn std::error::E
                 println!("  Validator:     {}", status.is_validator);
                 println!("  Read Only:     {}", status.is_read_only);
                 println!("  Ready:         {}", status.is_ready);
-                println!("  Epoch:         {} (length: {})", status.current_epoch, status.epoch_length);
+                println!(
+                    "  Epoch:         {} (length: {})",
+                    status.current_epoch, status.epoch_length
+                );
                 println!("  Version:       {}", status.version);
             } else {
                 println!(" Failed to get node status: HTTP {}", response.status());

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -37,13 +37,20 @@ pub async fn status_command(args: &HttpArgs) -> Result<(), Box<dyn std::error::E
                         status.native_token_decimals
                     );
                 }
-                println!("  LFB Number:    {}", status.last_finalized_block_number);
-                println!("  Validator:     {}", status.is_validator);
-                println!("  Read Only:     {}", status.is_read_only);
-                println!("  Ready:         {}", status.is_ready);
+                fn fmt<T: std::fmt::Display>(v: Option<T>) -> String {
+                    v.map(|x| x.to_string()).unwrap_or_else(|| "N/A".into())
+                }
+                println!(
+                    "  LFB Number:    {}",
+                    fmt(status.last_finalized_block_number)
+                );
+                println!("  Validator:     {}", fmt(status.is_validator));
+                println!("  Read Only:     {}", fmt(status.is_read_only));
+                println!("  Ready:         {}", fmt(status.is_ready));
                 println!(
                     "  Epoch:         {} (length: {})",
-                    status.current_epoch, status.epoch_length
+                    fmt(status.current_epoch),
+                    fmt(status.epoch_length)
                 );
                 println!("  Version:       {}", status.version);
             } else {

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -346,11 +346,7 @@ impl F1r3flyConnectionManager {
             cost: detail.as_ref().map(|d| d.cost),
             errored: detail.as_ref().map(|d| d.errored).unwrap_or(false),
             system_deploy_error: detail.and_then(|d| {
-                if d.system_deploy_error.is_empty() {
-                    None
-                } else {
-                    Some(d.system_deploy_error)
-                }
+                d.system_deploy_error.filter(|s| !s.is_empty())
             }),
             data,
         })

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -345,9 +345,8 @@ impl F1r3flyConnectionManager {
             block_number: detail.as_ref().map(|d| d.block_number),
             cost: detail.as_ref().map(|d| d.cost),
             errored: detail.as_ref().map(|d| d.errored).unwrap_or(false),
-            system_deploy_error: detail.and_then(|d| {
-                d.system_deploy_error.filter(|s| !s.is_empty())
-            }),
+            system_deploy_error: detail
+                .and_then(|d| d.system_deploy_error.filter(|s| !s.is_empty())),
             data,
         })
     }

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -76,8 +76,8 @@ impl Dispatcher {
                 .await
                 .map_err(NodeCliError::from),
             Commands::GetNodeId(args) => get_node_id_command(args).map_err(NodeCliError::from),
-            Commands::WatchBlocks(args) => {
-                watch_blocks_command(args).await.map_err(NodeCliError::from)
+            Commands::WatchEvents(args) => {
+                watch_events_command(args).await.map_err(NodeCliError::from)
             }
             Commands::Dag(args) => run_dag(args).await,
             Commands::BlockTransfers(args) => block_transfers_command(args)
@@ -158,7 +158,7 @@ impl Dispatcher {
             Commands::NetworkConsensus(_) => "network-consensus",
             Commands::GetBlocksByHeight(_) => "get-blocks-by-height",
             Commands::GetNodeId(_) => "get-node-id",
-            Commands::WatchBlocks(_) => "watch-blocks",
+            Commands::WatchEvents(_) => "watch-events",
             Commands::Dag(_) => "dag",
             Commands::BlockTransfers(_) => "block-transfers",
 

--- a/src/f1r3fly_api.rs
+++ b/src/f1r3fly_api.rs
@@ -25,11 +25,11 @@ pub struct NodeStatus {
     pub nodes: i32,
     #[serde(rename = "minPhloPrice")]
     pub min_phlo_price: i64,
-    #[serde(rename = "nativeTokenName")]
+    #[serde(rename = "nativeTokenName", default)]
     pub native_token_name: String,
-    #[serde(rename = "nativeTokenSymbol")]
+    #[serde(rename = "nativeTokenSymbol", default)]
     pub native_token_symbol: String,
-    #[serde(rename = "nativeTokenDecimals")]
+    #[serde(rename = "nativeTokenDecimals", default)]
     pub native_token_decimals: u32,
     #[serde(rename = "peerList", default)]
     pub peer_list: Vec<serde_json::Value>,

--- a/src/f1r3fly_api.rs
+++ b/src/f1r3fly_api.rs
@@ -12,6 +12,29 @@ use serde::{Deserialize, Serialize};
 pub use crate::grpc::query::extract_par_data;
 pub use crate::grpc::F1r3flyApi;
 
+/// Node status from `/api/status`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeStatus {
+    pub version: serde_json::Value,
+    pub address: String,
+    #[serde(rename = "networkId")]
+    pub network_id: String,
+    #[serde(rename = "shardId")]
+    pub shard_id: String,
+    pub peers: i32,
+    pub nodes: i32,
+    #[serde(rename = "minPhloPrice")]
+    pub min_phlo_price: i64,
+    #[serde(rename = "nativeTokenName")]
+    pub native_token_name: String,
+    #[serde(rename = "nativeTokenSymbol")]
+    pub native_token_symbol: String,
+    #[serde(rename = "nativeTokenDecimals")]
+    pub native_token_decimals: u32,
+    #[serde(rename = "peerList", default)]
+    pub peer_list: Vec<serde_json::Value>,
+}
+
 /// Deploy execution detail from the node's `/api/deploy/{id}` endpoint
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeployDetail {

--- a/src/f1r3fly_api.rs
+++ b/src/f1r3fly_api.rs
@@ -33,18 +33,20 @@ pub struct NodeStatus {
     pub native_token_decimals: u32,
     #[serde(rename = "peerList", default)]
     pub peer_list: Vec<serde_json::Value>,
+    // Numeric and bool fields use Option so a missing field (e.g. from an older
+    // Scala node) is distinguishable from a real zero/false value.
     #[serde(rename = "lastFinalizedBlockNumber", default)]
-    pub last_finalized_block_number: i64,
+    pub last_finalized_block_number: Option<i64>,
     #[serde(rename = "isValidator", default)]
-    pub is_validator: bool,
+    pub is_validator: Option<bool>,
     #[serde(rename = "isReadOnly", default)]
-    pub is_read_only: bool,
+    pub is_read_only: Option<bool>,
     #[serde(rename = "isReady", default)]
-    pub is_ready: bool,
+    pub is_ready: Option<bool>,
     #[serde(rename = "currentEpoch", default)]
-    pub current_epoch: i64,
+    pub current_epoch: Option<i64>,
     #[serde(rename = "epochLength", default)]
-    pub epoch_length: i32,
+    pub epoch_length: Option<i32>,
 }
 
 /// Deploy execution detail from the node's `/api/deploy/{id}` endpoint.

--- a/src/f1r3fly_api.rs
+++ b/src/f1r3fly_api.rs
@@ -33,31 +33,50 @@ pub struct NodeStatus {
     pub native_token_decimals: u32,
     #[serde(rename = "peerList", default)]
     pub peer_list: Vec<serde_json::Value>,
+    #[serde(rename = "lastFinalizedBlockNumber", default)]
+    pub last_finalized_block_number: i64,
+    #[serde(rename = "isValidator", default)]
+    pub is_validator: bool,
+    #[serde(rename = "isReadOnly", default)]
+    pub is_read_only: bool,
+    #[serde(rename = "isReady", default)]
+    pub is_ready: bool,
+    #[serde(rename = "currentEpoch", default)]
+    pub current_epoch: i64,
+    #[serde(rename = "epochLength", default)]
+    pub epoch_length: i32,
 }
 
-/// Deploy execution detail from the node's `/api/deploy/{id}` endpoint
+/// Deploy execution detail from the node's `/api/deploy/{id}` endpoint.
+/// Unified DeployResponse — full view includes all fields,
+/// summary view omits Optional fields.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeployDetail {
+    #[serde(rename = "deployId")]
+    pub deploy_id: String,
     #[serde(rename = "blockHash")]
     pub block_hash: String,
     #[serde(rename = "blockNumber")]
     pub block_number: i64,
     pub timestamp: i64,
-    pub deployer: String,
-    pub term: String,
     pub cost: u64,
     pub errored: bool,
-    #[serde(rename = "systemDeployError")]
-    pub system_deploy_error: String,
-    #[serde(rename = "phloPrice")]
-    pub phlo_price: i64,
-    #[serde(rename = "phloLimit")]
-    pub phlo_limit: i64,
-    pub sig: String,
-    #[serde(rename = "sigAlgorithm")]
-    pub sig_algorithm: String,
-    #[serde(rename = "validAfterBlockNumber")]
-    pub valid_after_block_number: i64,
+    #[serde(rename = "isFinalized")]
+    pub is_finalized: bool,
+    #[serde(default)]
+    pub deployer: Option<String>,
+    #[serde(default)]
+    pub term: Option<String>,
+    #[serde(rename = "systemDeployError", default)]
+    pub system_deploy_error: Option<String>,
+    #[serde(rename = "phloPrice", default)]
+    pub phlo_price: Option<i64>,
+    #[serde(rename = "phloLimit", default)]
+    pub phlo_limit: Option<i64>,
+    #[serde(rename = "sigAlgorithm", default)]
+    pub sig_algorithm: Option<String>,
+    #[serde(rename = "validAfterBlockNumber", default)]
+    pub valid_after_block_number: Option<i64>,
 }
 
 /// Result of a full deploy-and-wait operation

--- a/src/grpc/http.rs
+++ b/src/grpc/http.rs
@@ -57,7 +57,7 @@ impl<'a> F1r3flyApi<'a> {
         http_port: u16,
     ) -> Result<Option<DeployDetail>, Box<dyn std::error::Error>> {
         let url = format!(
-            "http://{}:{}/api/deploy/{}?view=detail",
+            "http://{}:{}/api/deploy/{}",
             self.node_host, http_port, deploy_id
         );
         let client = reqwest::Client::new();

--- a/src/grpc/http.rs
+++ b/src/grpc/http.rs
@@ -67,10 +67,10 @@ impl<'a> F1r3flyApi<'a> {
             return Ok(None);
         }
 
-        match response.json::<DeployDetail>().await {
-            Ok(detail) => Ok(Some(detail)),
-            Err(_) => Ok(None),
-        }
+        // None is reserved for 404 (handled above). A JSON parse error is a real
+        // problem — schema mismatch, malformed response, etc. — and must surface.
+        let detail = response.json::<DeployDetail>().await?;
+        Ok(Some(detail))
     }
 
     /// Get deploy info using the default view (works on all nodes).

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,0 +1,460 @@
+//! Integration smoke tests against a running F1R3FLY node.
+//!
+//! Works against both standalone nodes and multi-validator shards.
+//! Configure via environment variables:
+//!   F1R3FLY_HOST          (default: localhost)
+//!   F1R3FLY_HTTP_PORT     (default: 40413, validator1 HTTP)
+//!   F1R3FLY_OBSERVER_HTTP (default: 40453, readonly HTTP)
+//!
+//! Standalone (CI):  F1R3FLY_HTTP_PORT=40463 F1R3FLY_OBSERVER_HTTP=40463
+//! Shard (local):    defaults work (40413 validator, 40453 readonly)
+//!
+//! Run: cargo test --test smoke --release
+//! Skip if no node: tests return Ok(()) when connection fails.
+
+use reqwest::Client;
+use serde_json::Value;
+
+fn host() -> String {
+    std::env::var("F1R3FLY_HOST").unwrap_or_else(|_| "localhost".into())
+}
+fn http_port() -> u16 {
+    std::env::var("F1R3FLY_HTTP_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(40413)
+}
+fn observer_http() -> u16 {
+    std::env::var("F1R3FLY_OBSERVER_HTTP")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(40453)
+}
+
+fn api_url(port: u16, path: &str) -> String {
+    format!("http://{}:{}/api{}", host(), port, path)
+}
+
+async fn get_json(port: u16, path: &str) -> Option<Value> {
+    let url = api_url(port, path);
+    match Client::new().get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => resp.json().await.ok(),
+        _ => None,
+    }
+}
+
+async fn post_json(port: u16, path: &str, body: Value) -> Option<Value> {
+    let url = api_url(port, path);
+    match Client::new().post(&url).json(&body).send().await {
+        Ok(resp) if resp.status().is_success() => resp.json().await.ok(),
+        _ => None,
+    }
+}
+
+async fn get_status_code(port: u16, path: &str) -> Option<u16> {
+    let url = api_url(port, path);
+    Client::new().get(&url).send().await.ok().map(|r| r.status().as_u16())
+}
+
+async fn post_status_code(port: u16, path: &str, body: Value) -> Option<u16> {
+    let url = api_url(port, path);
+    Client::new().post(&url).json(&body).send().await.ok().map(|r| r.status().as_u16())
+}
+
+/// Skip test if node not reachable
+async fn require_shard() -> bool {
+    get_json(http_port(), "/status").await.is_some()
+}
+
+/// True when validator and observer point to the same node (standalone mode)
+fn is_standalone() -> bool {
+    http_port() == observer_http()
+}
+
+// ============================================================================
+// Status
+// ============================================================================
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_status_fields() {
+    if !require_shard().await { return; }
+
+    let status = get_json(http_port(), "/status").await.unwrap();
+
+    // Core fields
+    assert!(status["version"]["api"].is_string());
+    assert!(status["version"]["node"].is_string());
+    assert!(status["address"].is_string());
+    assert!(status["networkId"].is_string());
+    assert!(status["shardId"].is_string());
+    assert!(status["peers"].is_number());
+    assert!(status["nodes"].is_number());
+    assert!(status["minPhloPrice"].is_number());
+
+    // Token metadata
+    assert!(status["nativeTokenName"].is_string());
+    assert!(status["nativeTokenSymbol"].is_string());
+    assert!(status["nativeTokenDecimals"].is_number());
+
+    // Operational state (Phase 4b)
+    assert!(status["lastFinalizedBlockNumber"].is_number());
+    assert!(status["isValidator"].is_boolean());
+    assert!(status["isReadOnly"].is_boolean());
+    assert!(status["isReady"].is_boolean());
+    assert!(status["currentEpoch"].is_number());
+    assert!(status["epochLength"].is_number());
+
+    assert_eq!(status["isReady"], true, "node should be ready");
+    assert!(status["epochLength"].as_i64().unwrap() > 0, "epochLength should be > 0");
+}
+
+// ============================================================================
+// Blocks
+// ============================================================================
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_last_finalized_block_full() {
+    if !require_shard().await { return; }
+
+    let lfb = get_json(http_port(), "/last-finalized-block").await.unwrap();
+
+    assert!(lfb["blockInfo"].is_object(), "missing blockInfo");
+    assert!(lfb["deploys"].is_array(), "full view should have deploys");
+
+    let info = &lfb["blockInfo"];
+    assert!(info["blockHash"].is_string());
+    assert!(info["blockNumber"].as_i64().unwrap() >= 0);
+    assert!(info["isFinalized"].as_bool().unwrap(), "LFB should be finalized");
+    assert!(info["faultTolerance"].is_number());
+}
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_last_finalized_block_summary() {
+    if !require_shard().await { return; }
+
+    let lfb = get_json(http_port(), "/last-finalized-block?view=summary").await.unwrap();
+
+    assert!(lfb["blockInfo"].is_object(), "missing blockInfo");
+    assert!(lfb.get("deploys").is_none(), "summary should omit deploys");
+}
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_block_by_hash() {
+    if !require_shard().await { return; }
+
+    let lfb = get_json(http_port(), "/last-finalized-block").await.unwrap();
+    let hash = lfb["blockInfo"]["blockHash"].as_str().unwrap();
+
+    let block = get_json(http_port(), &format!("/block/{}", hash)).await.unwrap();
+
+    assert_eq!(block["blockInfo"]["blockHash"], hash);
+    assert!(block["blockInfo"]["isFinalized"].as_bool().unwrap());
+    assert!(block["deploys"].is_array(), "full view should have deploys");
+}
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_block_summary_view() {
+    if !require_shard().await { return; }
+
+    let lfb = get_json(http_port(), "/last-finalized-block").await.unwrap();
+    let hash = lfb["blockInfo"]["blockHash"].as_str().unwrap();
+
+    let block = get_json(http_port(), &format!("/block/{}?view=summary", hash)).await.unwrap();
+
+    assert!(block["blockInfo"].is_object());
+    assert!(block.get("deploys").is_none(), "summary should omit deploys");
+}
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_blocks_list_summary_default() {
+    if !require_shard().await { return; }
+
+    let blocks = get_json(http_port(), "/blocks/5").await.unwrap();
+    let arr = blocks.as_array().unwrap();
+    assert!(!arr.is_empty(), "should have blocks");
+
+    for b in arr {
+        assert!(b["blockInfo"].is_object(), "should have blockInfo wrapper");
+        assert!(b["blockInfo"]["blockHash"].is_string());
+        assert!(b.get("deploys").is_none(), "summary default should omit deploys");
+    }
+}
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_blocks_list_full_view() {
+    if !require_shard().await { return; }
+
+    let blocks = get_json(http_port(), "/blocks/5?view=full").await.unwrap();
+    let arr = blocks.as_array().unwrap();
+    assert!(!arr.is_empty());
+
+    let has_deploys = arr.iter().any(|b| b.get("deploys").is_some());
+    assert!(has_deploys, "full view should include deploys on at least one block");
+}
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_blocks_by_height_range() {
+    if !require_shard().await { return; }
+
+    let lfb = get_json(http_port(), "/last-finalized-block").await.unwrap();
+    let lfb_num = lfb["blockInfo"]["blockNumber"].as_i64().unwrap();
+    let start = (lfb_num - 2).max(0);
+
+    let blocks = get_json(http_port(), &format!("/blocks/{}/{}", start, lfb_num)).await.unwrap();
+    let arr = blocks.as_array().unwrap();
+    assert!(!arr.is_empty());
+
+    for b in arr {
+        let bn = b["blockInfo"]["blockNumber"].as_i64().unwrap();
+        assert!(bn >= start && bn <= lfb_num, "block #{} outside range {}-{}", bn, start, lfb_num);
+    }
+}
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_is_finalized() {
+    if !require_shard().await { return; }
+
+    let lfb = get_json(http_port(), "/last-finalized-block").await.unwrap();
+    let hash = lfb["blockInfo"]["blockHash"].as_str().unwrap();
+
+    let result = get_json(http_port(), &format!("/is-finalized/{}", hash)).await.unwrap();
+    assert_eq!(result, true);
+}
+
+// ============================================================================
+// Deploys
+// ============================================================================
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_prepare_deploy() {
+    if !require_shard().await { return; }
+
+    let result = get_json(http_port(), "/prepare-deploy").await.unwrap();
+
+    assert!(result["seqNumber"].is_number());
+    assert!(result.get("names").is_some());
+}
+
+// ============================================================================
+// Exploratory Deploy
+// ============================================================================
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_explore_deploy() {
+    if !require_shard().await { return; }
+
+    let body = serde_json::json!({"term": "new ret in { ret!(42) }"});
+    let result = post_json(observer_http(), "/explore-deploy", body).await.unwrap();
+
+    assert!(result["cost"].as_u64().unwrap() > 0, "cost should be > 0");
+    assert!(result["expr"].is_array());
+    assert!(result["block"].is_object());
+}
+
+// ============================================================================
+// High-Level Query Endpoints
+// ============================================================================
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_epoch() {
+    if !require_shard().await { return; }
+
+    // Works on all node types
+    let result = get_json(http_port(), "/epoch").await.unwrap();
+
+    assert!(result["currentEpoch"].is_number());
+    assert!(result["epochLength"].as_i64().unwrap() > 0);
+    assert!(result["quarantineLength"].is_number());
+    assert!(result["blocksUntilNextEpoch"].as_i64().unwrap() > 0);
+    assert!(result["lastFinalizedBlockNumber"].is_number());
+    assert!(result["blockHash"].is_string());
+
+    // Derived field check
+    let lfb = result["lastFinalizedBlockNumber"].as_i64().unwrap();
+    let epoch_len = result["epochLength"].as_i64().unwrap();
+    let expected_epoch = lfb / epoch_len;
+    assert_eq!(result["currentEpoch"].as_i64().unwrap(), expected_epoch);
+}
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_validators() {
+    if !require_shard().await { return; }
+
+    let result = get_json(observer_http(), "/validators").await.unwrap();
+
+    assert!(result["validators"].is_array());
+    assert!(result["totalStake"].as_i64().unwrap() > 0);
+    assert!(result["blockNumber"].is_number());
+    assert!(result["blockHash"].is_string());
+
+    let validators = result["validators"].as_array().unwrap();
+    assert!(validators.len() >= 2, "should have at least 2 validators");
+
+    for v in validators {
+        assert!(v["publicKey"].is_string());
+        assert!(v["stake"].as_i64().unwrap() > 0);
+    }
+}
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_validator_bonded() {
+    if !require_shard().await { return; }
+
+    // Get a real validator pubkey
+    let validators = get_json(observer_http(), "/validators").await.unwrap();
+    let pubkey = validators["validators"][0]["publicKey"].as_str().unwrap();
+
+    let result = get_json(observer_http(), &format!("/validator/{}", pubkey)).await.unwrap();
+
+    assert_eq!(result["publicKey"], pubkey);
+    assert_eq!(result["isBonded"], true);
+    assert!(result["stake"].as_i64().unwrap() > 0);
+}
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_validator_unknown() {
+    if !require_shard().await { return; }
+
+    let fake = "aa".repeat(65);
+    let result = get_json(observer_http(), &format!("/validator/{}", fake)).await.unwrap();
+
+    assert_eq!(result["isBonded"], false);
+    assert!(result["stake"].is_null());
+}
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_bond_status_bonded() {
+    if !require_shard().await { return; }
+
+    // Get real pubkey from LFB bonds
+    let lfb = get_json(http_port(), "/last-finalized-block").await.unwrap();
+    let pubkey = lfb["blockInfo"]["bonds"][0]["validator"].as_str().unwrap();
+
+    // Works on all node types (no exploratory deploy)
+    let result = get_json(http_port(), &format!("/bond-status/{}", pubkey)).await.unwrap();
+
+    assert_eq!(result["publicKey"], pubkey);
+    assert_eq!(result["isBonded"], true);
+}
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_bond_status_unknown() {
+    if !require_shard().await { return; }
+
+    let fake = "bb".repeat(65);
+    let result = get_json(http_port(), &format!("/bond-status/{}", fake)).await.unwrap();
+
+    assert_eq!(result["isBonded"], false);
+}
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_epoch_rewards() {
+    if !require_shard().await { return; }
+
+    let result = get_json(observer_http(), "/epoch/rewards").await.unwrap();
+
+    assert!(result["rewards"].is_object());
+    assert!(result["blockNumber"].is_number());
+    assert!(result["blockHash"].is_string());
+
+    // Rewards should be an ExprMap
+    assert!(result["rewards"]["ExprMap"].is_object());
+}
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_estimate_cost() {
+    if !require_shard().await { return; }
+
+    let body = serde_json::json!({"term": "new ret in { ret!(42) }"});
+    let result = post_json(observer_http(), "/estimate-cost", body).await.unwrap();
+
+    assert!(result["cost"].as_u64().unwrap() > 0);
+    assert!(result["blockNumber"].is_number());
+    assert!(result["blockHash"].is_string());
+}
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_estimate_cost_invalid_syntax() {
+    if !require_shard().await { return; }
+
+    let body = serde_json::json!({"term": "invalid {{{{ rholang"});
+    let url = api_url(observer_http(), "/estimate-cost");
+    let resp = Client::new().post(&url).json(&body).send().await.unwrap();
+
+    assert!(!resp.status().is_success(), "invalid syntax should fail");
+}
+
+// ============================================================================
+// Removed Endpoints
+// ============================================================================
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_removed_data_at_name_returns_404() {
+    if !require_shard().await { return; }
+
+    let body = serde_json::json!({"name": {"UnforgDeploy": {"data": "abc"}}, "depth": 1});
+    let code = post_status_code(http_port(), "/data-at-name", body).await.unwrap();
+    assert_eq!(code, 404);
+}
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_removed_transactions_returns_404() {
+    if !require_shard().await { return; }
+
+    let code = get_status_code(http_port(), "/transactions/abc123").await.unwrap();
+    assert_eq!(code, 404);
+}
+
+// ============================================================================
+// View Parameter Edge Cases
+// ============================================================================
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_unknown_view_defaults_to_full() {
+    if !require_shard().await { return; }
+
+    // Unknown view should return full (with deploys)
+    let block = get_json(http_port(), "/last-finalized-block?view=bogus").await.unwrap();
+    assert!(block["deploys"].is_array(), "unknown view should default to full");
+}
+
+// ============================================================================
+// Query with explicit block_hash
+// ============================================================================
+
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_epoch_with_block_hash() {
+    if !require_shard().await { return; }
+
+    let lfb = get_json(http_port(), "/last-finalized-block").await.unwrap();
+    let hash = lfb["blockInfo"]["blockHash"].as_str().unwrap();
+
+    let result = get_json(http_port(), &format!("/epoch?block_hash={}", hash)).await.unwrap();
+
+    assert_eq!(result["blockHash"], hash);
+    assert!(result["epochLength"].as_i64().unwrap() > 0);
+}

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -381,7 +381,13 @@ async fn test_validators() {
     assert!(result["blockHash"].is_string());
 
     let validators = result["validators"].as_array().unwrap();
-    assert!(validators.len() >= 2, "should have at least 2 validators");
+    let min = if is_standalone() { 1 } else { 2 };
+    assert!(
+        validators.len() >= min,
+        "expected at least {} validators, got {}",
+        min,
+        validators.len()
+    );
 
     for v in validators {
         assert!(v["publicKey"].is_string());

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -53,12 +53,23 @@ async fn post_json(port: u16, path: &str, body: Value) -> Option<Value> {
 
 async fn get_status_code(port: u16, path: &str) -> Option<u16> {
     let url = api_url(port, path);
-    Client::new().get(&url).send().await.ok().map(|r| r.status().as_u16())
+    Client::new()
+        .get(&url)
+        .send()
+        .await
+        .ok()
+        .map(|r| r.status().as_u16())
 }
 
 async fn post_status_code(port: u16, path: &str, body: Value) -> Option<u16> {
     let url = api_url(port, path);
-    Client::new().post(&url).json(&body).send().await.ok().map(|r| r.status().as_u16())
+    Client::new()
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .ok()
+        .map(|r| r.status().as_u16())
 }
 
 /// Skip test if node not reachable
@@ -78,7 +89,9 @@ fn is_standalone() -> bool {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_status_fields() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
     let status = get_json(http_port(), "/status").await.unwrap();
 
@@ -106,7 +119,10 @@ async fn test_status_fields() {
     assert!(status["epochLength"].is_number());
 
     assert_eq!(status["isReady"], true, "node should be ready");
-    assert!(status["epochLength"].as_i64().unwrap() > 0, "epochLength should be > 0");
+    assert!(
+        status["epochLength"].as_i64().unwrap() > 0,
+        "epochLength should be > 0"
+    );
 }
 
 // ============================================================================
@@ -116,9 +132,13 @@ async fn test_status_fields() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_last_finalized_block_full() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
-    let lfb = get_json(http_port(), "/last-finalized-block").await.unwrap();
+    let lfb = get_json(http_port(), "/last-finalized-block")
+        .await
+        .unwrap();
 
     assert!(lfb["blockInfo"].is_object(), "missing blockInfo");
     assert!(lfb["deploys"].is_array(), "full view should have deploys");
@@ -126,16 +146,23 @@ async fn test_last_finalized_block_full() {
     let info = &lfb["blockInfo"];
     assert!(info["blockHash"].is_string());
     assert!(info["blockNumber"].as_i64().unwrap() >= 0);
-    assert!(info["isFinalized"].as_bool().unwrap(), "LFB should be finalized");
+    assert!(
+        info["isFinalized"].as_bool().unwrap(),
+        "LFB should be finalized"
+    );
     assert!(info["faultTolerance"].is_number());
 }
 
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_last_finalized_block_summary() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
-    let lfb = get_json(http_port(), "/last-finalized-block?view=summary").await.unwrap();
+    let lfb = get_json(http_port(), "/last-finalized-block?view=summary")
+        .await
+        .unwrap();
 
     assert!(lfb["blockInfo"].is_object(), "missing blockInfo");
     assert!(lfb.get("deploys").is_none(), "summary should omit deploys");
@@ -144,12 +171,18 @@ async fn test_last_finalized_block_summary() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_block_by_hash() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
-    let lfb = get_json(http_port(), "/last-finalized-block").await.unwrap();
+    let lfb = get_json(http_port(), "/last-finalized-block")
+        .await
+        .unwrap();
     let hash = lfb["blockInfo"]["blockHash"].as_str().unwrap();
 
-    let block = get_json(http_port(), &format!("/block/{}", hash)).await.unwrap();
+    let block = get_json(http_port(), &format!("/block/{}", hash))
+        .await
+        .unwrap();
 
     assert_eq!(block["blockInfo"]["blockHash"], hash);
     assert!(block["blockInfo"]["isFinalized"].as_bool().unwrap());
@@ -159,21 +192,32 @@ async fn test_block_by_hash() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_block_summary_view() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
-    let lfb = get_json(http_port(), "/last-finalized-block").await.unwrap();
+    let lfb = get_json(http_port(), "/last-finalized-block")
+        .await
+        .unwrap();
     let hash = lfb["blockInfo"]["blockHash"].as_str().unwrap();
 
-    let block = get_json(http_port(), &format!("/block/{}?view=summary", hash)).await.unwrap();
+    let block = get_json(http_port(), &format!("/block/{}?view=summary", hash))
+        .await
+        .unwrap();
 
     assert!(block["blockInfo"].is_object());
-    assert!(block.get("deploys").is_none(), "summary should omit deploys");
+    assert!(
+        block.get("deploys").is_none(),
+        "summary should omit deploys"
+    );
 }
 
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_blocks_list_summary_default() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
     let blocks = get_json(http_port(), "/blocks/5").await.unwrap();
     let arr = blocks.as_array().unwrap();
@@ -182,51 +226,77 @@ async fn test_blocks_list_summary_default() {
     for b in arr {
         assert!(b["blockInfo"].is_object(), "should have blockInfo wrapper");
         assert!(b["blockInfo"]["blockHash"].is_string());
-        assert!(b.get("deploys").is_none(), "summary default should omit deploys");
+        assert!(
+            b.get("deploys").is_none(),
+            "summary default should omit deploys"
+        );
     }
 }
 
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_blocks_list_full_view() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
     let blocks = get_json(http_port(), "/blocks/5?view=full").await.unwrap();
     let arr = blocks.as_array().unwrap();
     assert!(!arr.is_empty());
 
     let has_deploys = arr.iter().any(|b| b.get("deploys").is_some());
-    assert!(has_deploys, "full view should include deploys on at least one block");
+    assert!(
+        has_deploys,
+        "full view should include deploys on at least one block"
+    );
 }
 
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_blocks_by_height_range() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
-    let lfb = get_json(http_port(), "/last-finalized-block").await.unwrap();
+    let lfb = get_json(http_port(), "/last-finalized-block")
+        .await
+        .unwrap();
     let lfb_num = lfb["blockInfo"]["blockNumber"].as_i64().unwrap();
     let start = (lfb_num - 2).max(0);
 
-    let blocks = get_json(http_port(), &format!("/blocks/{}/{}", start, lfb_num)).await.unwrap();
+    let blocks = get_json(http_port(), &format!("/blocks/{}/{}", start, lfb_num))
+        .await
+        .unwrap();
     let arr = blocks.as_array().unwrap();
     assert!(!arr.is_empty());
 
     for b in arr {
         let bn = b["blockInfo"]["blockNumber"].as_i64().unwrap();
-        assert!(bn >= start && bn <= lfb_num, "block #{} outside range {}-{}", bn, start, lfb_num);
+        assert!(
+            bn >= start && bn <= lfb_num,
+            "block #{} outside range {}-{}",
+            bn,
+            start,
+            lfb_num
+        );
     }
 }
 
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_is_finalized() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
-    let lfb = get_json(http_port(), "/last-finalized-block").await.unwrap();
+    let lfb = get_json(http_port(), "/last-finalized-block")
+        .await
+        .unwrap();
     let hash = lfb["blockInfo"]["blockHash"].as_str().unwrap();
 
-    let result = get_json(http_port(), &format!("/is-finalized/{}", hash)).await.unwrap();
+    let result = get_json(http_port(), &format!("/is-finalized/{}", hash))
+        .await
+        .unwrap();
     assert_eq!(result, true);
 }
 
@@ -237,7 +307,9 @@ async fn test_is_finalized() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_prepare_deploy() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
     let result = get_json(http_port(), "/prepare-deploy").await.unwrap();
 
@@ -252,10 +324,14 @@ async fn test_prepare_deploy() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_explore_deploy() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
     let body = serde_json::json!({"term": "new ret in { ret!(42) }"});
-    let result = post_json(observer_http(), "/explore-deploy", body).await.unwrap();
+    let result = post_json(observer_http(), "/explore-deploy", body)
+        .await
+        .unwrap();
 
     assert!(result["cost"].as_u64().unwrap() > 0, "cost should be > 0");
     assert!(result["expr"].is_array());
@@ -269,7 +345,9 @@ async fn test_explore_deploy() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_epoch() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
     // Works on all node types
     let result = get_json(http_port(), "/epoch").await.unwrap();
@@ -291,7 +369,9 @@ async fn test_epoch() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_validators() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
     let result = get_json(observer_http(), "/validators").await.unwrap();
 
@@ -312,13 +392,17 @@ async fn test_validators() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_validator_bonded() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
     // Get a real validator pubkey
     let validators = get_json(observer_http(), "/validators").await.unwrap();
     let pubkey = validators["validators"][0]["publicKey"].as_str().unwrap();
 
-    let result = get_json(observer_http(), &format!("/validator/{}", pubkey)).await.unwrap();
+    let result = get_json(observer_http(), &format!("/validator/{}", pubkey))
+        .await
+        .unwrap();
 
     assert_eq!(result["publicKey"], pubkey);
     assert_eq!(result["isBonded"], true);
@@ -328,10 +412,14 @@ async fn test_validator_bonded() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_validator_unknown() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
     let fake = "aa".repeat(65);
-    let result = get_json(observer_http(), &format!("/validator/{}", fake)).await.unwrap();
+    let result = get_json(observer_http(), &format!("/validator/{}", fake))
+        .await
+        .unwrap();
 
     assert_eq!(result["isBonded"], false);
     assert!(result["stake"].is_null());
@@ -340,14 +428,20 @@ async fn test_validator_unknown() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_bond_status_bonded() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
     // Get real pubkey from LFB bonds
-    let lfb = get_json(http_port(), "/last-finalized-block").await.unwrap();
+    let lfb = get_json(http_port(), "/last-finalized-block")
+        .await
+        .unwrap();
     let pubkey = lfb["blockInfo"]["bonds"][0]["validator"].as_str().unwrap();
 
     // Works on all node types (no exploratory deploy)
-    let result = get_json(http_port(), &format!("/bond-status/{}", pubkey)).await.unwrap();
+    let result = get_json(http_port(), &format!("/bond-status/{}", pubkey))
+        .await
+        .unwrap();
 
     assert_eq!(result["publicKey"], pubkey);
     assert_eq!(result["isBonded"], true);
@@ -356,10 +450,14 @@ async fn test_bond_status_bonded() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_bond_status_unknown() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
     let fake = "bb".repeat(65);
-    let result = get_json(http_port(), &format!("/bond-status/{}", fake)).await.unwrap();
+    let result = get_json(http_port(), &format!("/bond-status/{}", fake))
+        .await
+        .unwrap();
 
     assert_eq!(result["isBonded"], false);
 }
@@ -367,7 +465,9 @@ async fn test_bond_status_unknown() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_epoch_rewards() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
     let result = get_json(observer_http(), "/epoch/rewards").await.unwrap();
 
@@ -382,10 +482,14 @@ async fn test_epoch_rewards() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_estimate_cost() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
     let body = serde_json::json!({"term": "new ret in { ret!(42) }"});
-    let result = post_json(observer_http(), "/estimate-cost", body).await.unwrap();
+    let result = post_json(observer_http(), "/estimate-cost", body)
+        .await
+        .unwrap();
 
     assert!(result["cost"].as_u64().unwrap() > 0);
     assert!(result["blockNumber"].is_number());
@@ -395,7 +499,9 @@ async fn test_estimate_cost() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_estimate_cost_invalid_syntax() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
     let body = serde_json::json!({"term": "invalid {{{{ rholang"});
     let url = api_url(observer_http(), "/estimate-cost");
@@ -411,19 +517,27 @@ async fn test_estimate_cost_invalid_syntax() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_removed_data_at_name_returns_404() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
     let body = serde_json::json!({"name": {"UnforgDeploy": {"data": "abc"}}, "depth": 1});
-    let code = post_status_code(http_port(), "/data-at-name", body).await.unwrap();
+    let code = post_status_code(http_port(), "/data-at-name", body)
+        .await
+        .unwrap();
     assert_eq!(code, 404);
 }
 
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_removed_transactions_returns_404() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
-    let code = get_status_code(http_port(), "/transactions/abc123").await.unwrap();
+    let code = get_status_code(http_port(), "/transactions/abc123")
+        .await
+        .unwrap();
     assert_eq!(code, 404);
 }
 
@@ -434,11 +548,18 @@ async fn test_removed_transactions_returns_404() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_unknown_view_defaults_to_full() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
     // Unknown view should return full (with deploys)
-    let block = get_json(http_port(), "/last-finalized-block?view=bogus").await.unwrap();
-    assert!(block["deploys"].is_array(), "unknown view should default to full");
+    let block = get_json(http_port(), "/last-finalized-block?view=bogus")
+        .await
+        .unwrap();
+    assert!(
+        block["deploys"].is_array(),
+        "unknown view should default to full"
+    );
 }
 
 // ============================================================================
@@ -448,12 +569,18 @@ async fn test_unknown_view_defaults_to_full() {
 #[tokio::test]
 #[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
 async fn test_epoch_with_block_hash() {
-    if !require_shard().await { return; }
+    if !require_shard().await {
+        return;
+    }
 
-    let lfb = get_json(http_port(), "/last-finalized-block").await.unwrap();
+    let lfb = get_json(http_port(), "/last-finalized-block")
+        .await
+        .unwrap();
     let hash = lfb["blockInfo"]["blockHash"].as_str().unwrap();
 
-    let result = get_json(http_port(), &format!("/epoch?block_hash={}", hash)).await.unwrap();
+    let result = get_json(http_port(), &format!("/epoch?block_hash={}", hash))
+        .await
+        .unwrap();
 
     assert_eq!(result["blockHash"], hash);
     assert!(result["epochLength"].as_i64().unwrap() > 0);


### PR DESCRIPTION
## Summary

Four commits from staging for merge into dev:

1. **feat: update for API redesign, add integration tests, CI shard** (`0db2f3a`)
   - `DeployDetail`: `deployId` (not `sig`), `isFinalized`, optional fields
   - `NodeStatus`: 6 new operational fields (LFB, validator, ready, epoch)
   - Block list parser handles `blockInfo` wrapper; rejects blocks missing `isFinalized`
   - `watch-events`: `block-number`, `timestamp`, `TransfersAvailable` event; dropped `BlockApprovalReceived`
   - Removed `?view=detail` (default is full)
   - Fix: transfer/bond finalization timeout was hardcoded 30s, now honors `max_wait`
   - Added `tests/smoke.rs` (24 Rust integration tests, `#[ignore]`) and extended `scripts/smoke_test.sh` to 39 tests
   - CI: smoke + integration now run against a full shard (bootstrap + 3 validators + readonly)

2. **merge: feat/native-token-metadata** (`6adf33e`)
3. **feat: display native token metadata in status command** (`70855d3`)
4. **feat: support all 9 event types, rename watch-blocks to watch-events** (`4e3499e`)

## Test plan

- [x] `cargo build --release`
- [x] `./scripts/smoke_test.sh` — 39 tests pass against local shard (`f1r3fly-rust-node:local`)
- [x] `cargo test --test smoke -- --ignored` — 24 tests pass against local shard
- [ ] CI build-and-test against `dev`

Co-Authored-By: Claude <noreply@anthropic.com>