### PR TITLE
 feat(query): expand extract_par_data for URIs/bytes/collections 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,55 +4,22 @@ All notable changes to the F1r3fly rust-client will be documented in this file.
 This changelog is automatically generated from conventional commits.
 
 
-## [0.1.3] - 2026-04-23
+## [0.2.0] - 2026-05-05
 
 ### Bug Fixes
 
 - address PR review feedback
 - tolerate Scala node in status, WS events, and smoke tests
+- update epoch-rewards smoke test to verify parsed output
+- use HTTP API for epoch-rewards to parse full response data
+- use correct URI rho:vault:system in test_systemvault.rho
 
 ### CI
 
 - revert Rust CI to standalone node
-
-### Features
-
-- update for API redesign, add integration tests, CI shard
-- display native token metadata in status command
-- support all 9 event types, rename watch-blocks to watch-events
-
-### Deps
-
-- switch from path to git tag rust-v0.4.13
-
-### Style
-
-- apply cargo fmt
-
-
-## [0.1.2] - 2026-04-10
-
-### Refactoring
-
-- client library restructure, new commands, docs (#16)
-
-
-## [0.1.1] - 2026-03-30
-
-### CI
-
 - install protobuf-compiler for models build.rs
 - add arch-specific RUSTFLAGS for gxhash (aes+neon on arm64)
 - add build, test, and release workflows
-
-
-## [0.1.0] - 2026-03-17
-
-### Bug Fixes
-
-- update epoch-rewards smoke test to verify parsed output
-- use HTTP API for epoch-rewards to parse full response data
-- use correct URI rho:vault:system in test_systemvault.rho
 
 ### Documentation
 
@@ -62,14 +29,27 @@ This changelog is automatically generated from conventional commits.
 
 ### Features
 
+- expand extract_par_data to handle URIs, bytes, and collections
+- update for API redesign, add integration tests, CI shard
+- display native token metadata in status command
+- support all 9 event types, rename watch-blocks to watch-events
 - align with f1r3node PR #398 - RevAddress → VaultAddress rename
 
 ### Refactoring
 
+- client library restructure, new commands, docs (#16)
 - address PR #10 review feedback
+
+### Deps
+
+- switch from path to git tag rust-v0.4.13
 
 ### Smoke_test
 
 - build release first, portable timeout for macOS
+
+### Style
+
+- apply cargo fmt
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ This changelog is automatically generated from conventional commits.
 - support all 9 event types, rename watch-blocks to watch-events
 - align with f1r3node PR #398 - RevAddress → VaultAddress rename
 
+### Miscellaneous
+
+- increase default timeouts
+
 ### Refactoring
 
 - client library restructure, new commands, docs (#16)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -574,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crossbeam-deque"
@@ -780,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -1234,9 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1444,7 +1444,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -1668,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1764,9 +1764,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1811,9 +1811,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libz-ng-sys"
@@ -1953,12 +1953,12 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
 dependencies = [
- "ahash",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
@@ -2190,15 +2190,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2222,9 +2221,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -2747,6 +2746,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2895,7 +2903,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -2966,7 +2974,7 @@ dependencies = [
  "itertools 0.14.0",
  "k256",
  "lazy_static",
- "metrics 0.24.3",
+ "metrics 0.24.5",
  "models",
  "num-bigint",
  "num-integer",
@@ -3162,9 +3170,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "ring",
@@ -3185,9 +3193,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3445,7 +3453,7 @@ dependencies = [
  "http-body-util",
  "indexmap",
  "lz4_flex",
- "metrics 0.24.3",
+ "metrics 0.24.5",
  "proptest",
  "prost",
  "rand 0.9.4",
@@ -3825,9 +3833,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -3932,7 +3940,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.13",
+ "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -4288,9 +4296,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
  "indexmap",
  "serde",
@@ -4300,9 +4308,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4392,9 +4400,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4405,9 +4413,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4415,9 +4423,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4425,9 +4433,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4438,9 +4446,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -4481,9 +4489,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/src/args.rs
+++ b/src/args.rs
@@ -147,11 +147,11 @@ pub struct DeployAndWaitArgs {
     pub propose: bool,
 
     /// Maximum seconds to wait for deploy inclusion in a block
-    #[arg(long = "max-wait", default_value_t = 60)]
+    #[arg(long = "max-wait", default_value_t = 300)]
     pub max_wait: u64,
 
     /// Maximum seconds to wait for block finalization
-    #[arg(long = "finalization-timeout", default_value_t = 30)]
+    #[arg(long = "finalization-timeout", default_value_t = 180)]
     pub finalization_timeout: u64,
 
     /// Check interval in seconds

--- a/src/grpc/query.rs
+++ b/src/grpc/query.rs
@@ -130,15 +130,61 @@ impl<'a> F1r3flyApi<'a> {
 }
 
 pub fn extract_par_data(par: &Par) -> Option<String> {
+    use f1r3fly_models::rhoapi::expr::ExprInstance;
+
     if !par.exprs.is_empty() && par.exprs[0].expr_instance.is_some() {
         let expr = &par.exprs[0];
         if let Some(instance) = &expr.expr_instance {
             match instance {
-                f1r3fly_models::rhoapi::expr::ExprInstance::GString(s) => {
-                    Some(format!("\"{}\"", s))
+                ExprInstance::GString(s) => Some(format!("\"{}\"", s)),
+                ExprInstance::GUri(u) => Some(format!("`{}`", u)),
+                ExprInstance::GInt(i) => Some(i.to_string()),
+                ExprInstance::GBool(b) => Some(b.to_string()),
+                ExprInstance::GByteArray(bytes) => Some(format!("0x{}", hex::encode(bytes))),
+                ExprInstance::EListBody(list) => {
+                    let items: Vec<String> = list
+                        .ps
+                        .iter()
+                        .map(|p| extract_par_data(p).unwrap_or_else(|| "?".to_string()))
+                        .collect();
+                    Some(format!("[{}]", items.join(", ")))
                 }
-                f1r3fly_models::rhoapi::expr::ExprInstance::GInt(i) => Some(i.to_string()),
-                f1r3fly_models::rhoapi::expr::ExprInstance::GBool(b) => Some(b.to_string()),
+                ExprInstance::ETupleBody(tup) => {
+                    let items: Vec<String> = tup
+                        .ps
+                        .iter()
+                        .map(|p| extract_par_data(p).unwrap_or_else(|| "?".to_string()))
+                        .collect();
+                    Some(format!("({})", items.join(", ")))
+                }
+                ExprInstance::ESetBody(set) => {
+                    let items: Vec<String> = set
+                        .ps
+                        .iter()
+                        .map(|p| extract_par_data(p).unwrap_or_else(|| "?".to_string()))
+                        .collect();
+                    Some(format!("Set({{{}}})", items.join(", ")))
+                }
+                ExprInstance::EMapBody(map) => {
+                    let items: Vec<String> = map
+                        .kvs
+                        .iter()
+                        .map(|kv| {
+                            let k = kv
+                                .key
+                                .as_ref()
+                                .and_then(extract_par_data)
+                                .unwrap_or_else(|| "?".to_string());
+                            let v = kv
+                                .value
+                                .as_ref()
+                                .and_then(extract_par_data)
+                                .unwrap_or_else(|| "?".to_string());
+                            format!("{}: {}", k, v)
+                        })
+                        .collect();
+                    Some(format!("{{{}}}", items.join(", ")))
+                }
                 _ => Some("Complex expression".to_string()),
             }
         } else {


### PR DESCRIPTION
## Summary
  - Expand `extract_par_data` to render `GUri`, `GByteArray`, `EList`, `ETuple`, `ESet`, `EMap` recursively instead of collapsing them to `"Complex expression"`.
  - URIs render as `` `rho:id:...` ``, byte arrays as `0x<hex>`, collections use Rholang-style brackets/braces; unknown sub-Pars fall back to `?`.
  - No API change — same `Option<String>` return, same call sites.

  ## Motivation
  `exploratory-deploy` and `listen-data-at-name` results that contained registry URIs, hashes, lists, or maps were unreadable (printed `Complex expression`). Now they round-trip to a human-readable
   form close to Rholang source.

## example output

``` bash
Deploying and waiting for finalization...
Deploy ID: 3045022100c01590a158bcce79cc8b9f09fce6a579497afce5b5e0d517774fa37a8a7d4d5b02200a4d6f87802a330c9fe64a0eb5c2991f1f13adb49529a36f666f81c0dde1c58c
Block hash: 547764d0411cacf436fc1a650f44651c7af0bbade3fcf5c0a8889e9e9f2883cb
Block number: 54
Cost: 216309
Data[0]: ["lock lookup ok", `rho:id:tphk7efnzfydyrfqpcnifnc7m5ayom7bi55em5y888szdayx37m4in`]
Data[1]: ["lock call start", "1111AtahZeefej4tvVR6ti9TJtv8yxLebT31SCEVDCKMNikBk5r3g", 1000000000]
Data[2]: {"amount": 1000000000, "nonce": 3, "status": "ok"}
Total time: 31.52s
```