### PR TITLE
feat: deploy-status command and sig-level finalization polling

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -318,24 +318,28 @@ jobs:
         shell: bash -ex {0}
         env:
           IMAGE_TAG: ${{ needs.build_base.outputs.IMAGE_TAG }}
+          # Scala node doesn't publish :staging — pin to :dev. Rust uses
+          # the dynamic IMAGE_TAG (:staging on staging, :dev elsewhere).
+          SCALA_IMAGE_TAG: dev
         run: |
           if [ "${{ matrix.node }}" = "rust" ]; then
             docker pull f1r3flyindustries/f1r3fly-rust-node:${IMAGE_TAG}
           else
-            docker pull f1r3flyindustries/f1r3fly-scala-node:${IMAGE_TAG}
+            docker pull f1r3flyindustries/f1r3fly-scala-node:${SCALA_IMAGE_TAG}
           fi
 
       - name: Start node
         shell: bash -ex {0}
         env:
           IMAGE_TAG: ${{ needs.build_base.outputs.IMAGE_TAG }}
+          SCALA_IMAGE_TAG: dev
         run: |
           cd system-integration/integration-tests
           if [ "${{ matrix.node }}" = "rust" ]; then
             F1R3FLY_RUST_IMAGE="f1r3flyindustries/f1r3fly-rust-node:${IMAGE_TAG}" \
               docker compose -f docker-compose.standalone-rust.yml up -d
           else
-            F1R3FLY_SCALA_IMAGE="f1r3flyindustries/f1r3fly-scala-node:${IMAGE_TAG}" \
+            F1R3FLY_SCALA_IMAGE="f1r3flyindustries/f1r3fly-scala-node:${SCALA_IMAGE_TAG}" \
               docker compose -f docker-compose.standalone-scala.yml up -d
           fi
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -96,7 +96,10 @@ jobs:
           VERSION="${VERSION#v}"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
-          # Find related HEAD branch
+          # Find related HEAD branch.
+          # For PRs, use the *target* (base) branch — image selection should
+          # match what the target branch will use post-merge, not what the
+          # source feature branch happens to be named.
           BRANCH=""
           if [[ $GITHUB_REF =~ ^refs/tags/ ]]; then
             # For tag pushes, determine release type from tag name
@@ -111,6 +114,8 @@ jobs:
             fi
           elif [[ $GITHUB_REF =~ ^refs/heads/ ]]; then
             BRANCH=${GITHUB_REF#refs/*/}
+          elif [ -n "$GITHUB_BASE_REF" ]; then
+            BRANCH=$GITHUB_BASE_REF
           else
             BRANCH=$GITHUB_HEAD_REF
           fi

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,11 +6,13 @@ on:
     branches:
       - main
       - dev
+      - staging
     tags: "v**"
   pull_request:
     branches:
       - main
       - dev
+      - staging
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -115,8 +117,13 @@ jobs:
           echo "BRANCH=$BRANCH" >> $GITHUB_ENV
 
           # Determine f1r3node Docker image tag.
-          # Temporary: all branches use :dev until upstream cuts a :latest with the new API endpoints.
-          echo "IMAGE_TAG=dev" >> $GITHUB_ENV
+          # staging branch tracks rust/staging upstream → :staging image
+          # main / dev / tags use :dev (temporary: until upstream cuts a :latest with the new API endpoints)
+          if [ "$BRANCH" = "staging" ]; then
+            echo "IMAGE_TAG=staging" >> $GITHUB_ENV
+          else
+            echo "IMAGE_TAG=dev" >> $GITHUB_ENV
+          fi
 
       - name: Pack Working Tree
         shell: bash -ex {0}

--- a/docs/commands/deploy-and-wait.md
+++ b/docs/commands/deploy-and-wait.md
@@ -1,13 +1,14 @@
 # deploy-and-wait
 
-Deploy Rholang code, wait for block inclusion and finalization, then read the result.
+Deploy Rholang code, wait for canonical-state finalization, then read the result.
 
 This is the primary command for deploying contracts. It handles the full lifecycle:
 1. Deploy code via gRPC
-2. Poll until the deploy appears in a block
-3. Wait for the block to be finalized (via observer node)
-4. Read the `deployId` channel data from the finalized block
-5. Get deploy execution details (cost, errored)
+2. Poll the deploy signature via `/api/deploy-finalization-status` until terminal state (preferred path)
+3. Read the `deployId` channel data from the finalized block (using `latest_block_hash` from the status response)
+4. Get deploy execution details (cost, errored)
+
+**Note:** Step 2 used to be two separate phases (block inclusion + block finalization) using gRPC polling. That older path is still available as a fallback when the node doesn't expose `/api/deploy-finalization-status` (404), with a deprecation warning. Block-level polling can misreport success when a deploy is dropped during merge of a finalized block; sig-level polling is correct in that case.
 
 ## Usage
 
@@ -80,13 +81,16 @@ Block proposed: abc123...
 
 ## Timeouts
 
-The command has two timeout phases:
+On the preferred (sig-level) path, `--max-wait` and `--finalization-timeout` are summed into a single budget for sig polling at 2s intervals. The deploy must reach a terminal state (`Finalized`, `Failed`, or `Expired`) within that combined budget.
+
+- `Failed` → command exits with error indicating Rholang execution failure
+- `Expired` → command exits with error indicating the deploy never landed canonically
+- Timeout while still `Pending` → command exits with error
+
+On the legacy (block-hash) fallback path, the two timeouts apply separately as before:
 
 1. **Block inclusion** (`--max-wait`): polls `findDeploy` gRPC every `--check-interval` seconds until the deploy appears in a block. Default: 60s.
-
 2. **Finalization** (`--finalization-timeout`): polls `isFinalized` gRPC every 5 seconds on the observer node until the block is finalized. Default: 30s.
-
-If either timeout expires, the command exits with an error.
 
 ## Observer Node
 

--- a/docs/commands/deploy-status.md
+++ b/docs/commands/deploy-status.md
@@ -1,0 +1,61 @@
+# deploy-status
+
+Check canonical-state finalization status of a deploy by signature.
+
+Block-hash polling is insufficient for tracking deploy finalization: a block can finalize while some of its deploys' effects are dropped during merge. `deploy-status` polls the `/api/deploy-finalization-status/{sig}` endpoint and reports whether the deploy's effects are in canonical state.
+
+## Usage
+
+```bash
+node_cli deploy-status --sig <HEX> [OPTIONS]
+```
+
+## Flags
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--sig` | `-s` | required | Deploy signature in hex (with or without `0x` prefix) |
+| `--host` | `-H` | `localhost` | Node hostname |
+| `--http-port` | | `40413` | HTTP port (use the readonly observer port for shards) |
+| `--format` | `-f` | `pretty` | Output format: `pretty`, `json` |
+
+## Example
+
+```
+$ node_cli deploy-status -s 304502210085f163...
+
+Deploy Finalization Status
+----------------------------------------
+Sig:              304502210085f163934f0de4c8eadb177d62b9527997100ff3b80d868dbfa702c2...
+State:            Finalized
+Rejection count:  0
+Latest block:     79d3560b36998644d139ba0f73a3883274f28f22b6f2016e973f3606be38bb56
+Query time:       12.4ms
+```
+
+## States
+
+| State | Terminal | Meaning |
+|-------|----------|---------|
+| `Finalized` | yes | Clean inclusion in canonical-finalized block; effects are in canonical state |
+| `Failed` | yes | Rholang execution itself failed (insufficient phlo, contract error, etc.); effects will never apply |
+| `Pending` | no | Not yet canonical-finalized and not expired; keep polling |
+| `Expired` | yes | `valid_after_block_number + deploy_lifespan` elapsed without canonical inclusion |
+
+## Response fields
+
+| Field | Description |
+|-------|-------------|
+| `state` | One of the four states above |
+| `rejection_count` | Number of finalized blocks where the sig appears in `body.rejected_deploys`; non-zero means the deploy is contending |
+| `latest_block_hash` | Highest-block-number canonical block containing the sig (clean or rejected); `null` until first inclusion |
+
+## Polling guidance
+
+Block production is typically 5–30s. Poll every 2–5s until a terminal state is observed. Unknown sigs (just submitted, or never deployed) return `Pending` with `latest_block_hash: null` — keep polling rather than treating this as an error.
+
+## See also
+
+- [`deploy-and-wait`](deploy-and-wait.md) — uses this endpoint internally for sig-level finalization detection
+- [`get-deploy`](get-deploy.md) — historical lookup for already-finalized deploys (returns full execution detail)
+- [`is-finalized`](is-finalized.md) — block-level finalization check

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -577,24 +577,26 @@ else
     inc_fail
 fi
 
-# deploy-status: Canonical-state finalization status by deploy signature
-# Uses deploy ID from deploy-and-wait (which is the deploy signature in hex).
-# The deploy already finalized in that test, so state should be Finalized.
-if [ -n "${FDAW_DEPLOY_ID:-}" ]; then
+# deploy-status: Canonical-state finalization status by deploy signature.
+# Endpoint added in f1r3node PR #495+#504 — Rust-only.
+if [ "$NODE_TYPE" != "rust" ]; then
+    skip_test "deploy-status (finalized)" "rust-only (deploy-finalization-status endpoint)"
+    skip_test "deploy-status (unknown sig)" "rust-only (deploy-finalization-status endpoint)"
+elif [ -n "${FDAW_DEPLOY_ID:-}" ]; then
+    # Known sig from deploy-and-wait (with data) — should be Finalized.
     run_test "deploy-status (finalized)" \
         "cargo run -q --release -- deploy-status -s $FDAW_DEPLOY_ID -H $HOST --http-port $OBSERVER_HTTP" \
         "Deploy Finalization Status|State:.*Finalized"
+
+    # Unknown sig: all-zeros hex (64 chars) — should be Pending with no latest_block_hash.
+    run_test "deploy-status (unknown sig)" \
+        "cargo run -q --release -- deploy-status -s 0000000000000000000000000000000000000000000000000000000000000000 -H $HOST --http-port $OBSERVER_HTTP" \
+        "State:.*Pending"
 else
     echo -n "Testing deploy-status (finalized)... "
     echo -e "${RED}FAIL${NC} (no deploy ID from earlier tests)"
     inc_fail
 fi
-
-# deploy-status: Unknown sig should return Pending with no latest_block_hash.
-# Use a fixed all-zeros hex string (64 chars) — guaranteed unknown.
-run_test "deploy-status (unknown sig)" \
-    "cargo run -q --release -- deploy-status -s 0000000000000000000000000000000000000000000000000000000000000000 -H $HOST --http-port $OBSERVER_HTTP" \
-    "State:.*Pending"
 
 # ============================================
 # PoS QUERY COMMANDS

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -577,6 +577,25 @@ else
     inc_fail
 fi
 
+# deploy-status: Canonical-state finalization status by deploy signature
+# Uses deploy ID from deploy-and-wait (which is the deploy signature in hex).
+# The deploy already finalized in that test, so state should be Finalized.
+if [ -n "${FDAW_DEPLOY_ID:-}" ]; then
+    run_test "deploy-status (finalized)" \
+        "cargo run -q --release -- deploy-status -s $FDAW_DEPLOY_ID -H $HOST --http-port $OBSERVER_HTTP" \
+        "Deploy Finalization Status|State:.*Finalized"
+else
+    echo -n "Testing deploy-status (finalized)... "
+    echo -e "${RED}FAIL${NC} (no deploy ID from earlier tests)"
+    inc_fail
+fi
+
+# deploy-status: Unknown sig should return Pending with no latest_block_hash.
+# Use a fixed all-zeros hex string (64 chars) — guaranteed unknown.
+run_test "deploy-status (unknown sig)" \
+    "cargo run -q --release -- deploy-status -s 0000000000000000000000000000000000000000000000000000000000000000 -H $HOST --http-port $OBSERVER_HTTP" \
+    "State:.*Pending"
+
 # ============================================
 # PoS QUERY COMMANDS
 # ============================================

--- a/src/args.rs
+++ b/src/args.rs
@@ -114,6 +114,9 @@ pub enum Commands {
 
     /// Get transfer information from a block's deploys
     BlockTransfers(BlockTransfersArgs),
+
+    /// Check canonical-state finalization status of a deploy by signature
+    DeployStatus(DeployStatusArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -225,6 +228,26 @@ pub struct GetDeployArgs {
     /// Show full deploy details
     #[arg(long = "verbose")]
     pub verbose: bool,
+}
+
+/// Arguments for deploy-status command
+#[derive(Parser)]
+pub struct DeployStatusArgs {
+    /// Deploy signature in hex (with or without 0x prefix)
+    #[arg(short = 's', long = "sig")]
+    pub sig: String,
+
+    /// Node hostname
+    #[arg(short = 'H', long = "host", default_value = "localhost")]
+    pub host: String,
+
+    /// HTTP port for API queries
+    #[arg(long = "http-port", default_value_t = 40413)]
+    pub http_port: u16,
+
+    /// Output format (json, pretty)
+    #[arg(short = 'f', long = "format", default_value = "pretty")]
+    pub format: String,
 }
 
 /// Arguments for deploy and full-deploy commands

--- a/src/commands/network.rs
+++ b/src/commands/network.rs
@@ -709,3 +709,54 @@ pub async fn get_data_command(args: &GetDataArgs) -> crate::error::Result<()> {
 
     Ok(())
 }
+
+/// Check canonical-state finalization status of a deploy by signature.
+///
+/// Hits the node's `/api/deploy-finalization-status/{sig}` endpoint and
+/// renders the result. State is one of `Finalized`, `Failed`, `Pending`,
+/// `Expired` — see `DeployFinalizationStatus` for terminality semantics.
+pub async fn deploy_status_command(
+    args: &DeployStatusArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sig_hex = args.sig.trim_start_matches("0x");
+
+    // Reusing F1r3flyApi just for the HTTP method (port 0 is fine — never used here).
+    let api = F1r3flyApi::new(DEV_PRIVATE_KEY, &args.host, 0)?;
+    let start = Instant::now();
+
+    let status = match api
+        .deploy_finalization_status(sig_hex, args.http_port)
+        .await?
+    {
+        Some(s) => s,
+        None => {
+            return Err(format!(
+                "Endpoint /api/deploy-finalization-status not available on {}:{} \
+                 (404). This node may be running an older f1r3node version.",
+                args.host, args.http_port
+            )
+            .into());
+        }
+    };
+    let duration = start.elapsed();
+
+    match args.format.as_str() {
+        "json" => {
+            println!("{}", serde_json::to_string_pretty(&status)?);
+        }
+        _ => {
+            println!("Deploy Finalization Status");
+            println!("----------------------------------------");
+            println!("Sig:              {}", sig_hex);
+            println!("State:            {}", status.state);
+            println!("Rejection count:  {}", status.rejection_count);
+            match status.latest_block_hash.as_deref() {
+                Some(hash) => println!("Latest block:     {}", hash),
+                None => println!("Latest block:     (not yet included)"),
+            }
+            println!("Query time:       {:.2?}", duration);
+        }
+    }
+
+    Ok(())
+}

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -250,12 +250,85 @@ impl F1r3flyConnectionManager {
         ))
     }
 
-    /// Wait for a block to be finalized (uses observer node if configured)
+    /// Observer HTTP port — convention is observer_grpc_port + 1.
+    fn observer_http_port(&self) -> u16 {
+        self.config.observer_grpc_port.saturating_add(1)
+    }
+
+    /// Wait for a deploy to reach a terminal finalization state via the
+    /// `/api/deploy-finalization-status/{sig}` endpoint (sig-level polling).
+    ///
+    /// Polling stops on any terminal state (`Finalized` / `Failed` / `Expired`)
+    /// or when the budget elapses. Returns the final status, or
+    /// `Ok(None)` if the endpoint is unavailable on the node (404) — caller
+    /// should fall back to the legacy block-hash flow.
+    pub async fn wait_for_deploy_finalization(
+        &self,
+        deploy_sig_hex: &str,
+        total_timeout_secs: u64,
+        poll_interval_secs: u64,
+    ) -> Result<Option<crate::f1r3fly_api::DeployFinalizationStatus>, ConnectionError> {
+        let api = self.observer_api()?;
+        let http_port = self.observer_http_port();
+        let max_attempts = (total_timeout_secs / poll_interval_secs.max(1)).max(1) as u32;
+
+        for attempt in 1..=max_attempts {
+            match api
+                .deploy_finalization_status(deploy_sig_hex, http_port)
+                .await
+            {
+                Ok(Some(status)) => {
+                    if status.is_terminal() {
+                        tracing::debug!(
+                            deploy_sig = deploy_sig_hex,
+                            state = %status.state,
+                            attempt,
+                            "Deploy reached terminal state"
+                        );
+                        return Ok(Some(status));
+                    }
+                }
+                Ok(None) => {
+                    // 404 — endpoint not available on this node version.
+                    // Caller falls back to legacy flow.
+                    return Ok(None);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        deploy_sig = deploy_sig_hex,
+                        attempt,
+                        error = %e,
+                        "deploy-finalization-status query failed; will retry"
+                    );
+                }
+            }
+
+            if attempt < max_attempts {
+                tokio::time::sleep(tokio::time::Duration::from_secs(poll_interval_secs)).await;
+            }
+        }
+
+        Err(ConnectionError::OperationFailed(format!(
+            "Deploy {} did not reach terminal state within {}s",
+            deploy_sig_hex, total_timeout_secs
+        )))
+    }
+
+    /// Wait for a block to be finalized (uses observer node if configured).
+    ///
+    /// **Deprecated**: this performs block-level finalization polling, which
+    /// can mislead callers when a block finalizes but their deploy's effects
+    /// were dropped during merge. Use `wait_for_deploy_finalization` (sig-level)
+    /// when possible.
     pub async fn wait_for_finalization(
         &self,
         block_hash: &str,
         max_attempts: u32,
     ) -> Result<(), ConnectionError> {
+        tracing::warn!(
+            "wait_for_finalization is deprecated — block-level polling can miss \
+             merge-dropped deploys. Prefer wait_for_deploy_finalization."
+        );
         let api = self.observer_api()?;
         let retry_delay_sec = 5;
 
@@ -274,13 +347,16 @@ impl F1r3flyConnectionManager {
         }
     }
 
-    /// Deploy Rholang code, wait for finalization, and read result
+    /// Deploy Rholang code, wait for canonical-finalization, and read result.
     ///
-    /// 1. Deploy the code via gRPC
-    /// 2. Poll until the deploy appears in a block
-    /// 3. Wait for the block to be finalized (via observer)
-    /// 4. Read the deployId channel data from the finalized block
-    /// 5. Get deploy execution details (cost, errored)
+    /// Preferred path: sig-level polling via `/api/deploy-finalization-status`,
+    /// which reports whether the deploy's effects are in canonical state
+    /// (not just whether some containing block finalized).
+    ///
+    /// Legacy fallback: if the endpoint is unavailable (404), falls back to
+    /// the two-phase block-hash flow (find block + check block finalization)
+    /// with a deprecation warning. This older path can misreport success when
+    /// a deploy is dropped during merge of a finalized block.
     pub async fn deploy_and_wait(
         &self,
         rholang_code: &str,
@@ -296,22 +372,67 @@ impl F1r3flyConnectionManager {
             .map_err(|e| ConnectionError::OperationFailed(format!("Deploy failed: {}", e)))?;
         tracing::info!(deploy_id = %deploy_id, "Deploy submitted");
 
-        // Phase 2: Wait for block inclusion
-        let max_block_wait =
-            (self.config.deploy_timeout_secs as u64 / self.config.poll_interval_secs) as u32;
-        let block_hash = self.wait_for_deploy(&deploy_id, max_block_wait).await?;
-        tracing::info!(block_hash = %block_hash, "Deploy included in block");
+        // Phase 2: Sig-level polling (preferred), fall back to legacy on 404
+        const SIG_POLL_INTERVAL_SECS: u64 = 2;
+        let total_timeout = (self.config.deploy_timeout_secs as u64)
+            .saturating_add(self.config.finalization_timeout_secs as u64);
 
-        // Phase 3: Wait for finalization (via observer)
-        let finalization_poll_secs: u64 = 5;
-        let max_finalization =
-            (self.config.finalization_timeout_secs as u64 / finalization_poll_secs) as u32;
-        let max_finalization = max_finalization.max(1);
-        self.wait_for_finalization(&block_hash, max_finalization)
-            .await?;
-        tracing::info!("Block finalized");
+        let block_hash = match self
+            .wait_for_deploy_finalization(&deploy_id, total_timeout, SIG_POLL_INTERVAL_SECS)
+            .await?
+        {
+            Some(status) => match status.state.as_str() {
+                "Finalized" => {
+                    let block_hash = status.latest_block_hash.ok_or_else(|| {
+                        ConnectionError::OperationFailed(
+                            "Finalized state without latest_block_hash (node bug)".to_string(),
+                        )
+                    })?;
+                    tracing::info!(block_hash = %block_hash, "Deploy canonically finalized");
+                    block_hash
+                }
+                "Failed" => {
+                    return Err(ConnectionError::OperationFailed(format!(
+                        "Deploy {} failed during execution (Rholang error or insufficient phlo)",
+                        deploy_id
+                    )));
+                }
+                "Expired" => {
+                    return Err(ConnectionError::OperationFailed(format!(
+                        "Deploy {} expired without canonical inclusion",
+                        deploy_id
+                    )));
+                }
+                other => {
+                    return Err(ConnectionError::OperationFailed(format!(
+                        "Deploy {} in unexpected non-terminal state {} after timeout",
+                        deploy_id, other
+                    )));
+                }
+            },
+            None => {
+                tracing::warn!(
+                    "deploy-finalization-status endpoint unavailable; falling back to \
+                     legacy block-hash polling. This path will be removed once all \
+                     supported nodes ship the new endpoint."
+                );
+                let max_block_wait = (self.config.deploy_timeout_secs as u64
+                    / self.config.poll_interval_secs) as u32;
+                let block_hash = self.wait_for_deploy(&deploy_id, max_block_wait).await?;
+                tracing::info!(block_hash = %block_hash, "Deploy included in block");
 
-        // Phase 4: Read deploy result AFTER finalization
+                let finalization_poll_secs: u64 = 5;
+                let max_finalization = ((self.config.finalization_timeout_secs as u64
+                    / finalization_poll_secs) as u32)
+                    .max(1);
+                self.wait_for_finalization(&block_hash, max_finalization)
+                    .await?;
+                tracing::info!("Block finalized (legacy path)");
+                block_hash
+            }
+        };
+
+        // Phase 3: Read deploy result AFTER finalization
         // Empty data is normal when the contract doesn't write to deployId
         let data = match api.get_data_at_deploy_id(&deploy_id, &block_hash).await {
             Ok(data) => data,
@@ -326,7 +447,7 @@ impl F1r3flyConnectionManager {
             }
         };
 
-        // Phase 5: Get deploy execution details
+        // Phase 4: Get deploy execution details
         // May fail on older nodes that don't support ?view=detail
         let detail = match api
             .get_deploy_detail(&deploy_id, self.config.http_port)

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -83,6 +83,9 @@ impl Dispatcher {
             Commands::BlockTransfers(args) => block_transfers_command(args)
                 .await
                 .map_err(NodeCliError::from),
+            Commands::DeployStatus(args) => deploy_status_command(args)
+                .await
+                .map_err(NodeCliError::from),
         };
 
         // Handle errors with better formatting
@@ -161,6 +164,7 @@ impl Dispatcher {
             Commands::WatchEvents(_) => "watch-events",
             Commands::Dag(_) => "dag",
             Commands::BlockTransfers(_) => "block-transfers",
+            Commands::DeployStatus(_) => "deploy-status",
 
             Commands::GetData(_) => "get-data",
         }

--- a/src/f1r3fly_api.rs
+++ b/src/f1r3fly_api.rs
@@ -81,6 +81,28 @@ pub struct DeployDetail {
     pub valid_after_block_number: Option<i64>,
 }
 
+/// Canonical-state finalization status for a deploy, from
+/// `/api/deploy-finalization-status/{sig}`.
+///
+/// `state` is one of:
+/// - `"Finalized"` — clean inclusion in canonical-finalized block. Terminal.
+/// - `"Failed"` — Rholang execution itself failed. Terminal.
+/// - `"Pending"` — not yet canonical-finalized, not expired. Keep polling.
+/// - `"Expired"` — `valid_after_block_number + deploy_lifespan` elapsed
+///   (LFB-anchored) without a clean canonical inclusion. Terminal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeployFinalizationStatus {
+    pub state: String,
+    pub rejection_count: u32,
+    pub latest_block_hash: Option<String>,
+}
+
+impl DeployFinalizationStatus {
+    pub fn is_terminal(&self) -> bool {
+        matches!(self.state.as_str(), "Finalized" | "Failed" | "Expired")
+    }
+}
+
 /// Result of a full deploy-and-wait operation
 #[derive(Debug, Clone)]
 pub struct DeployResult {

--- a/src/grpc/http.rs
+++ b/src/grpc/http.rs
@@ -1,7 +1,7 @@
 //! HTTP-based methods on F1r3flyApi (deploy lookup, deploy detail)
 
 use super::F1r3flyApi;
-use crate::f1r3fly_api::DeployDetail;
+use crate::f1r3fly_api::{DeployDetail, DeployFinalizationStatus};
 
 impl<'a> F1r3flyApi<'a> {
     pub async fn get_deploy_block_hash(
@@ -71,6 +71,37 @@ impl<'a> F1r3flyApi<'a> {
         // problem — schema mismatch, malformed response, etc. — and must surface.
         let detail = response.json::<DeployDetail>().await?;
         Ok(Some(detail))
+    }
+
+    /// Query `/api/deploy-finalization-status/{deploy_sig_hex}` for canonical
+    /// finalization state of a deploy.
+    ///
+    /// Returns `Ok(Some(status))` on 200, `Ok(None)` on 404 (endpoint not
+    /// available on this node — caller should fall back to block-hash polling),
+    /// and `Err` on other failures (network, JSON parse, 5xx).
+    pub async fn deploy_finalization_status(
+        &self,
+        deploy_sig_hex: &str,
+        http_port: u16,
+    ) -> Result<Option<DeployFinalizationStatus>, Box<dyn std::error::Error>> {
+        let url = format!(
+            "http://{}:{}/api/deploy-finalization-status/{}",
+            self.node_host, http_port, deploy_sig_hex
+        );
+        let client = reqwest::Client::new();
+        let response = client.get(&url).send().await?;
+
+        if response.status().as_u16() == 404 {
+            return Ok(None);
+        }
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!("HTTP {} from {}: {}", status, url, body).into());
+        }
+
+        let status = response.json::<DeployFinalizationStatus>().await?;
+        Ok(Some(status))
     }
 
     /// Get deploy info using the default view (works on all nodes).

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -591,3 +591,76 @@ async fn test_epoch_with_block_hash() {
     assert_eq!(result["blockHash"], hash);
     assert!(result["epochLength"].as_i64().unwrap() > 0);
 }
+
+// ============================================================================
+// Deploy finalization status
+// ============================================================================
+
+/// Unknown sig should return Pending with empty fields, not 404 or 500.
+/// The endpoint deliberately reports `pending_unknown` for sigs the deploy
+/// index has never seen, so polling clients can keep retrying without
+/// distinguishing "just submitted" from "actually unknown".
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_deploy_finalization_status_unknown_sig() {
+    if !require_shard().await {
+        return;
+    }
+
+    let unknown_sig = "0".repeat(64);
+    let result = get_json(
+        observer_http(),
+        &format!("/deploy-finalization-status/{}", unknown_sig),
+    )
+    .await
+    .unwrap_or_else(|| panic!("endpoint returned non-200 for unknown sig"));
+
+    assert_eq!(result["state"], "Pending");
+    assert_eq!(result["rejection_count"], 0);
+    assert!(result["latest_block_hash"].is_null());
+}
+
+/// 0x prefix should be tolerated on the sig path parameter (the CLI
+/// strips it; this confirms the endpoint also accepts it).
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_deploy_finalization_status_invalid_hex_returns_400() {
+    if !require_shard().await {
+        return;
+    }
+
+    let bad_hex = "not-hex-at-all";
+    let code = get_status_code(
+        observer_http(),
+        &format!("/deploy-finalization-status/{}", bad_hex),
+    )
+    .await
+    .unwrap_or(0);
+
+    assert_eq!(code, 400, "expected 400 for invalid hex, got {}", code);
+}
+
+/// Response shape regression: state, rejection_count, latest_block_hash.
+/// Locks the JSON contract so unintentional renames break this test.
+#[tokio::test]
+#[ignore] // Requires running node. Run with: cargo test --test smoke --release -- --ignored
+async fn test_deploy_finalization_status_response_shape() {
+    if !require_shard().await {
+        return;
+    }
+
+    let unknown_sig = "1".repeat(64);
+    let result = get_json(
+        observer_http(),
+        &format!("/deploy-finalization-status/{}", unknown_sig),
+    )
+    .await
+    .unwrap();
+
+    let obj = result.as_object().expect("response is a JSON object");
+    assert!(obj.contains_key("state"));
+    assert!(obj.contains_key("rejection_count"));
+    assert!(obj.contains_key("latest_block_hash"));
+    assert!(obj["state"].is_string());
+    assert!(obj["rejection_count"].is_u64());
+}


### PR DESCRIPTION
## Summary

Adds support for the new `/api/deploy-finalization-status/{sig}` endpoint introduced in f1r3node PR #495 (resolver) and refined in PR #504 (edge-case fixes).

- New `deploy-status -s <sig>` command — query canonical-state finalization by deploy signature
- `deploy-and-wait` now polls the deploy signature directly instead of polling block-hash finalization. Block-level polling can misreport success when a deploy is dropped during merge of a finalized block; sig-level polling is correct in that case
- Backward-compatible: on 404 from the new endpoint, falls back to the legacy block-hash flow with a `tracing::warn!` deprecation message
- Same fix applies transitively to `transfer`, `bond-validator`, and `load-test` since they all route through `ConnectionManager.deploy_and_wait`

## CI

- Adds `staging` to push/PR triggers (was `main` + `dev` only)
- Maps `staging` branch → `:staging` f1r3node image; other branches → `:dev` (unchanged)

## States exposed by the new endpoint

| State | Terminal | Meaning |
|-------|----------|---------|
| `Finalized` | yes | Clean inclusion in canonical-finalized block |
| `Failed` | yes | Rholang execution itself failed |
| `Pending` | no | Not yet finalized, not expired — keep polling |
| `Expired` | yes | `valid_after_block_number + deploy_lifespan` elapsed |

## Files

- `src/f1r3fly_api.rs` — `DeployFinalizationStatus` type with `is_terminal()` helper
- `src/grpc/http.rs` — `deploy_finalization_status()` HTTP method (returns `Ok(None)` on 404)
- `src/args.rs`, `src/dispatcher.rs`, `src/commands/network.rs` — new `deploy-status` CLI command
- `src/connection_manager.rs` — new `wait_for_deploy_finalization`; legacy `wait_for_finalization` kept with deprecation warning; `deploy_and_wait` uses sig-level path with 404 fallback
- `scripts/smoke_test.sh` — two new tests (finalized known sig, unknown sig → Pending)
- `tests/smoke.rs` — three integration tests (unknown sig shape, invalid hex 400, response shape regression)
- `docs/commands/deploy-status.md` — new
- `docs/commands/deploy-and-wait.md` — updated for new flow
- `.github/workflows/build-and-test.yml` — staging trigger + image-tag selection

## Test plan

- [x] `cargo build --release`
- [x] `cargo fmt --check`
- [x] `cargo test --release` (unit tests pass; 3 new ignored integration tests registered)
- [ ] CI build/smoke against `:staging` image (requires PR #504 merged into rust/staging upstream first)
- [ ] Manual smoke against running shard

## Related

- Adds client support for f1r3node #495 (`deploy_finalization_status` resolver) + #504 (edge-case fixes)

Co-Authored-By: Claude <noreply@anthropic.com>