### PR TITLE
Support native token transfers with custom decimals

### DIFF
--- a/docs/commands/advanced.md
+++ b/docs/commands/advanced.md
@@ -12,7 +12,8 @@ node_cli load-test --to-address <ADDR> --num-tests <N> --amount <AMT> [OPTIONS]
 |------|---------|-------------|
 | `--to-address` | required | Recipient address |
 | `--num-tests` | required | Number of transfers to send |
-| `--amount` | required | Amount per transfer (tokens) |
+| `--amount` | required | Amount per transfer in base units (dust). Use `--whole-tokens`/`-d` for whole tokens. |
+| `--whole-tokens` | `-d` | false | Treat `--amount` as whole tokens, scaled by the native token's decimals from node status (default: base units / dust) |
 | `--interval` | `5` | Seconds between deploys |
 | `--inclusion-timeout` | `120` | Max seconds for block inclusion |
 | `--finalization-timeout` | `120` | Max seconds for finalization |
@@ -21,11 +22,11 @@ node_cli load-test --to-address <ADDR> --num-tests <N> --amount <AMT> [OPTIONS]
 | `--readonly-port` | same as port | Read-only gRPC port for balance check |
 
 ```
-$ node_cli load-test --to-address 11112oRq...r2L --num-tests 3 --amount 1
+$ node_cli load-test --to-address 11112oRq...r2L --num-tests 3 --amount 100000000
 
 F1R3FLY Load Test
 Tests: 3
-Amount: 1
+Amount: 100000000 dust
 Interval: 5s
 
 Test 1/3

--- a/docs/commands/transfer.md
+++ b/docs/commands/transfer.md
@@ -13,7 +13,7 @@ node_cli transfer --to-address <ADDRESS> --amount <AMOUNT> [OPTIONS]
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--to-address` | `-t` | required | Recipient vault address (starts with `1111`) |
-| `--amount` | `-a` | required | Amount in tokens (1 token = 100,000,000 dust) |
+| `--amount` | `-a` | required | Amount in base units (dust) by default. Use `--whole-tokens`/`-d` for whole tokens. |
 | `--private-key` | | dev key | Sender's signing key |
 | `--host` | `-H` | `localhost` | Node hostname |
 | `--port` | `-p` | `40412` | gRPC port |
@@ -26,11 +26,12 @@ node_cli transfer --to-address <ADDRESS> --amount <AMOUNT> [OPTIONS]
 | `--observer-port` | | `40452` | Observer gRPC port |
 | `--expiration` | | none | Expiration timestamp (ms) |
 | `--expires-in` | | none | Expiration duration (seconds) |
+| `--whole-tokens` | `-d` | false | Treat `--amount` as whole tokens, scaled by the native token's decimals from node status (default: base units / dust) |
 
 ## Example
 
 ```
-$ node_cli transfer --to-address 111127RX5ZgiAdRaQy4AWy57RdvAAckdELReEBxzvWYVvdnR32PiHA --amount 1
+$ node_cli transfer --to-address 111127RX5ZgiAdRaQy4AWy57RdvAAckdELReEBxzvWYVvdnR32PiHA --amount 100000000
 
 Transfer: 1111AtahZe...r3g -> 111127RX5Z...iHA (100000000 dust)
 Deploy ID:    3045022100...
@@ -40,9 +41,18 @@ Total time:   23.70s
 Transfer complete.
 ```
 
+Or with `--whole-tokens` / `-d` to specify whole tokens:
+
+```
+$ node_cli transfer --to-address 111127RX5ZgiAdRaQy4AWy57RdvAAckdELReEBxzvWYVvdnR32PiHA --amount 1 -d
+
+Transfer: 1111AtahZe...r3g -> 111127RX5Z...iHA (100000000 dust)
+...
+```
+
 ## Notes
 
 - The sender address is derived from the private key automatically
-- Amount is in whole tokens — converted to dust internally (1 token = 100,000,000 dust)
+- `--amount` is in base units (dust) by default; use `--whole-tokens`/`-d` to specify whole tokens (scaled by the native token's decimals fetched from node status)
 - Uses high phlo limit by default because transfer contracts are expensive
 - Vault addresses must start with `1111`

--- a/docs/library/getting-started.md
+++ b/docs/library/getting-started.md
@@ -65,6 +65,7 @@ println!("Estimated cost: {} phlogiston", cost);
 ### Transfer
 
 ```rust
+// amount is in base units (dust); use the CLI --whole-tokens flag for whole-token amounts
 let transfer = manager.transfer("1111recipient...", 100_000_000).await?;
 println!("TX: {} in block {}", transfer.deploy_id, transfer.block_hash);
 ```

--- a/src/args.rs
+++ b/src/args.rs
@@ -626,6 +626,9 @@ pub struct TransferArgs {
     /// Amount to transfer
     #[arg(short, long)]
     pub amount: u64,
+    /// Treat amount as a whole token(*10^decimals). Without it amount in base units (dust).
+    #[arg(short = 'd', long = "whole-tokens", default_value_t = false)]
+    pub whole_tokens: bool,
 
     /// Private key for signing the transfer (hex format)
     #[arg(

--- a/src/args.rs
+++ b/src/args.rs
@@ -626,7 +626,7 @@ pub struct TransferArgs {
     /// Amount to transfer
     #[arg(short, long)]
     pub amount: u64,
-    /// Treat amount as a whole token(*10^decimals). Without it amount in base units (dust).
+    /// Treat --amount as whole tokens, scaled by the native token's decimals from node status (default: base units / dust)
     #[arg(short = 'd', long = "whole-tokens", default_value_t = false)]
     pub whole_tokens: bool,
 
@@ -698,6 +698,10 @@ pub struct LoadTestArgs {
     /// Amount per transfer
     #[arg(long, default_value_t = 1)]
     pub amount: u64,
+
+    /// Treat --amount as whole tokens, scaled by the native token's decimals from node status (default: base units / dust)
+    #[arg(short = 'd', long = "whole-tokens", default_value_t = false)]
+    pub whole_tokens: bool,
 
     /// Seconds between tests
     #[arg(long, default_value_t = 10)]

--- a/src/commands/load_test.rs
+++ b/src/commands/load_test.rs
@@ -1,4 +1,5 @@
 use crate::args::LoadTestArgs;
+use crate::commands::query::query_node_status;
 use crate::f1r3fly_api::F1r3flyApi;
 use chrono::Local;
 use std::time::{Duration, Instant};
@@ -17,11 +18,29 @@ pub struct TestResult {
 pub async fn load_test_command(args: &LoadTestArgs) -> Result<(), Box<dyn std::error::Error>> {
     use crate::utils::CryptoUtils;
 
+    let amount_dust = if args.whole_tokens {
+        let (status_json, _) =
+            query_node_status(&reqwest::Client::new(), &args.host, args.http_port, false).await?;
+        let decimals = status_json
+            .get("nativeTokenDecimals")
+            .and_then(|v| v.as_u64())
+            .ok_or("node did not report token decimals; cannot convert whole tokens")?
+            as u32;
+        let factor = 10u64
+            .checked_pow(decimals)
+            .ok_or("token decimals too large for u64 multiplier")?;
+        args.amount
+            .checked_mul(factor)
+            .ok_or("amount overflows u64 after applying token decimals")?
+    } else {
+        args.amount
+    };
+
     println!("");
     println!(" F1R3FLY Load Test ");
     println!("");
     println!("Tests: {}", args.num_tests);
-    println!("Amount: {}", args.amount);
+    println!("Amount: {} dust", amount_dust);
     println!("Interval: {}s", args.interval);
     println!("Check interval: {}s (fast mode)", args.check_interval);
     println!("Target: {}:{}", args.host, args.port);
@@ -74,7 +93,7 @@ pub async fn load_test_command(args: &LoadTestArgs) -> Result<(), Box<dyn std::e
         println!("");
 
         // Run single test with detailed logging
-        let result = run_single_test(&api, args, test_num).await?;
+        let result = run_single_test(&api, args, test_num, amount_dust).await?;
 
         results.push(result);
 
@@ -98,6 +117,7 @@ async fn run_single_test(
     api: &F1r3flyApi<'_>,
     args: &LoadTestArgs,
     test_num: u32,
+    amount_dust: u64,
 ) -> Result<TestResult, Box<dyn std::error::Error>> {
     let test_start = Instant::now();
 
@@ -105,7 +125,7 @@ async fn run_single_test(
     println!(" [{}] Deploying transfer...", now_timestamp());
     let deploy_start = Instant::now();
 
-    let rholang = generate_transfer_contract(args);
+    let rholang = generate_transfer_contract(args, amount_dust);
     // Load tests don't use expiration timestamp (0 means no expiration)
     let deploy_id = api.deploy(&rholang, true, "rholang", 0).await?.to_string();
 
@@ -201,7 +221,7 @@ async fn run_single_test(
     })
 }
 
-fn generate_transfer_contract(args: &LoadTestArgs) -> String {
+fn generate_transfer_contract(args: &LoadTestArgs, amount_dust: u64) -> String {
     use crate::utils::CryptoUtils;
 
     // Derive sender address from private key
@@ -211,8 +231,6 @@ fn generate_transfer_contract(args: &LoadTestArgs) -> String {
     let public_key_hex = CryptoUtils::serialize_public_key(&public_key, false);
     let from_address =
         CryptoUtils::generate_vault_address(&public_key_hex).expect("Failed to generate address");
-
-    let amount_dust = args.amount * 100_000_000;
 
     format!(
         r#"new 
@@ -224,7 +242,7 @@ fn generate_transfer_contract(args: &LoadTestArgs) -> String {
  toVaultCh,
  systemVaultKeyCh,
  resultCh
-in {{
+ in {{
  rl!(`rho:vault:system`, *systemVaultCh) |
  for (@(_, SystemVault) <- systemVaultCh) {{
  @SystemVault!("findOrCreate", "{}", *vaultCh) |

--- a/src/commands/network.rs
+++ b/src/commands/network.rs
@@ -1,4 +1,5 @@
 use crate::args::*;
+use crate::commands::query::query_node_status;
 use crate::connection_manager::{ConnectionConfig, F1r3flyConnectionManager};
 use crate::f1r3fly_api::{F1r3flyApi, ProposeResult};
 use std::fs;
@@ -414,7 +415,25 @@ pub async fn transfer_command(args: &TransferArgs) -> Result<(), Box<dyn std::er
     validate_vault_address(&from_address)?;
     validate_vault_address(&args.to_address)?;
 
-    let amount_dust = args.amount * 100_000_000;
+    let amount_dust = if args.whole_tokens {
+        // Whole-token mode: ask the node how many decimals the native token has.
+        let (status_json, _) =
+            query_node_status(&reqwest::Client::new(), &args.host, args.http_port, false).await?;
+        let decimals = status_json
+            .get("nativeTokenDecimals")
+            .and_then(|v| v.as_u64())
+            .ok_or("node did not report token decimals; cannot convert whole tokens")?
+            as u32;
+        let factor = 10u64
+            .checked_pow(decimals)
+            .ok_or("token decimals too large for u64 multiplier")?;
+        args.amount
+            .checked_mul(factor)
+            .ok_or("amount overflows u64 after applying token decimals")?
+    } else {
+        args.amount
+    };
+
     println!(
         "Transfer: {} -> {} ({} dust)",
         from_address, args.to_address, amount_dust

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -34,7 +34,7 @@ pub async fn status_command(args: &HttpArgs) -> Result<(), Box<dyn std::error::E
                         "  Native Token:  {} ({}, {} decimals)",
                         status.native_token_name,
                         status.native_token_symbol,
-                        status.native_token_decimals
+                        fmt(status.native_token_decimals)
                     );
                 }
                 fn fmt<T: std::fmt::Display>(v: Option<T>) -> String {
@@ -551,7 +551,7 @@ impl DiscoveredPeer {
 }
 
 // Helper function to query a node's status and return full JSON response
-async fn query_node_status(
+pub(crate) async fn query_node_status(
     client: &reqwest::Client,
     host: &str,
     port: u16,

--- a/src/f1r3fly_api.rs
+++ b/src/f1r3fly_api.rs
@@ -30,7 +30,7 @@ pub struct NodeStatus {
     #[serde(rename = "nativeTokenSymbol", default)]
     pub native_token_symbol: String,
     #[serde(rename = "nativeTokenDecimals", default)]
-    pub native_token_decimals: u32,
+    pub native_token_decimals: Option<u32>,
     #[serde(rename = "peerList", default)]
     pub peer_list: Vec<serde_json::Value>,
     // Numeric and bool fields use Option so a missing field (e.g. from an older


### PR DESCRIPTION
- add `--whole-tokens`/`-d` flag: amount as whole tokens vs base units (dust)
- fetch native_token_decimals from node `api/status` (if transfer is carried out in whole tokens)
- compute amount_dust as amount `* 10^decimals` instead of hardcoded `*100_000_000`
- use checked_pow/checked_mul instead of panicking/wrapping on overflow

fix of #22 issue