### PR TITLE
fix: remove hardcoded private key from client source (issue #24)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ crc = "3"
 zbase32 = "0.1"
 
 # CLI-only (behind "cli" feature)
-clap = { version = "4.4.6", features = ["derive"], optional = true }
+clap = { version = "4.4.6", features = ["derive", "env"], optional = true }
 ratatui = { version = "0.28", optional = true }
 crossterm = { version = "0.28", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ cargo run --release -- exploratory-deploy -f query.rho -H localhost -p 40452
 cargo run --release -- exploratory-deploy -f rho_examples/query_token_metadata.rho -H localhost -p 40452
 ```
 
+## Local development
+
+Commands need a signing key, provided via `--private-key` or the `FIREFLY_PRIVATE_KEY` environment variable; if neither is set, the command exits with an error. Local dev/test Docker node setups are funded with a well-known development key (not a secret — it ships in those Docker configs). Export it when running against a local node:
+
+```bash
+export FIREFLY_PRIVATE_KEY=5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657
+```
+
 ## Documentation
 
 ### Commands

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -20,6 +20,7 @@ HTTP_PORT="${3:-40403}"      # HTTP port for status/query operations
 OBSERVER_GRPC="${4:-$GRPC_PORT}"  # Observer gRPC port (defaults to same as GRPC_PORT)
 OBSERVER_HTTP=$((OBSERVER_GRPC + 1))  # Observer HTTP port (gRPC + 1)
 PRIVATE_KEY="${5:-5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657}"  # Signing key
+export FIREFLY_PRIVATE_KEY="$PRIVATE_KEY"
 
 # Recipient address for transfers (secondary test address from genesis)
 TO_ADDR="11112oRqNpmKjfFCGgH6bw5csjBqVgb4PVRP5S98tTNjDeqdWNJr2L"

--- a/src/args.rs
+++ b/src/args.rs
@@ -245,10 +245,7 @@ pub struct DeployArgs {
     pub file: PathBuf,
 
     /// Private key in hex format
-    #[arg(
-        long,
-        env = "FIREFLY_PRIVATE_KEY"
-    )]
+    #[arg(long, env = "FIREFLY_PRIVATE_KEY")]
     pub private_key: String,
 
     /// Host address
@@ -338,11 +335,7 @@ pub struct ExploratoryDeployArgs {
 #[derive(Parser)]
 pub struct GeneratePublicKeyArgs {
     /// Private key in hex format
-    #[arg(
-        short,
-        long,
-        env = "FIREFLY_PRIVATE_KEY"
-    )]
+    #[arg(short, long, env = "FIREFLY_PRIVATE_KEY")]
     pub private_key: String,
 
     /// Output public key in compressed format (shorter)
@@ -576,10 +569,7 @@ pub struct TransferArgs {
     pub amount: u64,
 
     /// Private key for signing the transfer (hex format)
-    #[arg(
-        long,
-        env = "FIREFLY_PRIVATE_KEY"
-    )]
+    #[arg(long, env = "FIREFLY_PRIVATE_KEY")]
     pub private_key: String,
 
     /// Host address
@@ -649,10 +639,7 @@ pub struct LoadTestArgs {
     pub interval: u64,
 
     /// Private key for signing (hex format)
-    #[arg(
-        long,
-        env = "FIREFLY_PRIVATE_KEY"
-    )]
+    #[arg(long, env = "FIREFLY_PRIVATE_KEY")]
     pub private_key: String,
 
     /// Host address

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,11 +1,6 @@
 use clap::{ArgAction, Parser, Subcommand};
 use std::path::PathBuf;
 
-/// Well-known bootstrap validator private key used in dev/test Docker setups.
-/// NOT for production use.
-pub const DEV_PRIVATE_KEY: &str =
-    "5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657";
-
 /// Command-line interface for interacting with F1r3fly nodes
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -125,9 +120,9 @@ pub struct DeployAndWaitArgs {
     #[arg(short, long)]
     pub file: String,
 
-    /// Private key for deploy (defaults to well-known dev key)
-    #[arg(short = 'k', long = "private-key")]
-    pub private_key: Option<String>,
+    /// Private key for deploy (--private-key or FIREFLY_PRIVATE_KEY env)
+    #[arg(short = 'k', long = "private-key", env = "FIREFLY_PRIVATE_KEY")]
+    pub private_key: String,
 
     /// Node hostname
     #[arg(short = 'H', long = "host", default_value = "localhost")]
@@ -189,14 +184,6 @@ pub struct GetDataArgs {
     /// Block hash containing the deploy
     #[arg(short = 'b', long = "block-hash")]
     pub block_hash: String,
-
-    /// Private key (defaults to well-known dev key)
-    #[arg(
-        short = 'k',
-        long = "private-key",
-        default_value = "5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657"
-    )]
-    pub private_key: String,
 
     /// Node hostname
     #[arg(short = 'H', long = "host", default_value = "localhost")]
@@ -260,7 +247,7 @@ pub struct DeployArgs {
     /// Private key in hex format
     #[arg(
         long,
-        default_value = "5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657"
+        env = "FIREFLY_PRIVATE_KEY"
     )]
     pub private_key: String,
 
@@ -290,13 +277,6 @@ pub struct DeployArgs {
 /// Arguments for propose command
 #[derive(Parser)]
 pub struct ProposeArgs {
-    /// Private key in hex format
-    #[arg(
-        long,
-        default_value = "5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657"
-    )]
-    pub private_key: String,
-
     /// Host address
     #[arg(short = 'H', long, default_value = "localhost")]
     pub host: String,
@@ -312,13 +292,6 @@ pub struct IsFinalizedArgs {
     /// Block hash to check
     #[arg(short, long)]
     pub block_hash: String,
-
-    /// Private key in hex format
-    #[arg(
-        long,
-        default_value = "5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657"
-    )]
-    pub private_key: String,
 
     /// Host address
     #[arg(short = 'H', long, default_value = "localhost")]
@@ -344,13 +317,6 @@ pub struct ExploratoryDeployArgs {
     #[arg(short, long)]
     pub file: PathBuf,
 
-    /// Private key in hex format
-    #[arg(
-        long,
-        default_value = "5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657"
-    )]
-    pub private_key: String,
-
     /// Host address
     #[arg(short = 'H', long, default_value = "localhost")]
     pub host: String,
@@ -375,7 +341,7 @@ pub struct GeneratePublicKeyArgs {
     #[arg(
         short,
         long,
-        default_value = "5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657"
+        env = "FIREFLY_PRIVATE_KEY"
     )]
     pub private_key: String,
 
@@ -408,11 +374,7 @@ pub struct GenerateVaultAddressArgs {
     pub public_key: Option<String>,
 
     /// Private key in hex format (will derive public key from this)
-    #[arg(
-        long,
-        default_value = "5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657",
-        conflicts_with = "public_key"
-    )]
+    #[arg(long, conflicts_with = "public_key")]
     pub private_key: Option<String>,
 }
 
@@ -462,13 +424,6 @@ pub struct ShowMainChainArgs {
     /// Number of blocks to fetch from main chain (default: 10)
     #[arg(short, long, default_value_t = 10)]
     pub depth: u32,
-
-    /// Private key in hex format (required for gRPC)
-    #[arg(
-        long,
-        default_value = "5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657"
-    )]
-    pub private_key: String,
 }
 
 /// Arguments for get-blocks-by-height command
@@ -489,13 +444,6 @@ pub struct GetBlocksByHeightArgs {
     /// End block number (inclusive)
     #[arg(short, long)]
     pub end_block_number: i64,
-
-    /// Private key in hex format (required for gRPC)
-    #[arg(
-        long,
-        default_value = "5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657"
-    )]
-    pub private_key: String,
 }
 
 /// Arguments for wallet-balance command
@@ -630,7 +578,7 @@ pub struct TransferArgs {
     /// Private key for signing the transfer (hex format)
     #[arg(
         long,
-        default_value = "5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657"
+        env = "FIREFLY_PRIVATE_KEY"
     )]
     pub private_key: String,
 
@@ -703,7 +651,7 @@ pub struct LoadTestArgs {
     /// Private key for signing (hex format)
     #[arg(
         long,
-        default_value = "5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657"
+        env = "FIREFLY_PRIVATE_KEY"
     )]
     pub private_key: String,
 

--- a/src/commands/load_test.rs
+++ b/src/commands/load_test.rs
@@ -322,7 +322,7 @@ async fn get_balance_for_address(
     );
 
     // Create a separate API instance for read-only port
-    let readonly_api = F1r3flyApi::new(&args.private_key, &args.host, args.readonly_port)?;
+    let readonly_api = F1r3flyApi::new_readonly(&args.host, args.readonly_port);
 
     // Execute exploratory deploy to get balance on read-only node
     let (result, _block_info, _cost) = readonly_api

--- a/src/commands/network.rs
+++ b/src/commands/network.rs
@@ -4,8 +4,6 @@ use crate::f1r3fly_api::{F1r3flyApi, ProposeResult};
 use std::fs;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
-use crate::args::DEV_PRIVATE_KEY;
-
 fn build_config(
     host: &str,
     port: u16,
@@ -32,7 +30,7 @@ fn build_config(
 }
 
 fn config_from_deploy_args(args: &DeployAndWaitArgs) -> ConnectionConfig {
-    let private_key = args.private_key.as_deref().unwrap_or(DEV_PRIVATE_KEY);
+    let private_key = args.private_key.as_str();
     build_config(
         &args.host,
         args.port,
@@ -101,7 +99,7 @@ pub async fn exploratory_deploy_command(
 
     // Initialize the F1r3fly API client
     println!(" Connecting to F1r3fly node at {}:{}", args.host, args.port);
-    let f1r3fly_api = F1r3flyApi::new(&args.private_key, &args.host, args.port)?;
+    let f1r3fly_api = F1r3flyApi::new_readonly(&args.host, args.port);
 
     // Execute the exploratory deployment
     println!(" Executing Rholang code (exploratory deploy)...");
@@ -153,7 +151,7 @@ pub async fn estimate_cost_command(
     let rholang_code =
         fs::read_to_string(&args.file).map_err(|e| format!("Failed to read file: {}", e))?;
 
-    let f1r3fly_api = F1r3flyApi::new(&args.private_key, &args.host, args.port)?;
+    let f1r3fly_api = F1r3flyApi::new_readonly(&args.host, args.port);
 
     let (_result, _block_info, cost) = f1r3fly_api
         .exploratory_deploy(
@@ -224,7 +222,7 @@ pub async fn deploy_command(args: &DeployArgs) -> Result<(), Box<dyn std::error:
 pub async fn propose_command(args: &ProposeArgs) -> Result<(), Box<dyn std::error::Error>> {
     // Initialize the F1r3fly API client
     println!(" Connecting to F1r3fly node at {}:{}", args.host, args.port);
-    let f1r3fly_api = F1r3flyApi::new(&args.private_key, &args.host, args.port)?;
+    let f1r3fly_api = F1r3flyApi::new_readonly(&args.host, args.port);
 
     // Propose a block
     println!(" Proposing a new block...");
@@ -316,7 +314,7 @@ pub async fn is_finalized_command(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Initialize the F1r3fly API client
     println!(" Connecting to F1r3fly node at {}:{}", args.host, args.port);
-    let f1r3fly_api = F1r3flyApi::new(&args.private_key, &args.host, args.port)?;
+    let f1r3fly_api = F1r3flyApi::new_readonly(&args.host, args.port);
 
     // Check if the block is finalized
     println!(" Checking if block is finalized: {}", args.block_hash);
@@ -503,7 +501,7 @@ pub async fn deploy_and_wait_command(
     println!("Total time: {:.2?}", start.elapsed());
 
     if args.propose {
-        let private_key = args.private_key.as_deref().unwrap_or(DEV_PRIVATE_KEY);
+        let private_key = args.private_key.as_str();
         let api = F1r3flyApi::new(private_key, &args.host, args.port)?;
         match api.propose().await {
             Ok(ProposeResult::Proposed(hash)) => println!("Block proposed: {}", hash),
@@ -516,7 +514,7 @@ pub async fn deploy_and_wait_command(
 }
 
 pub async fn get_deploy_command(args: &GetDeployArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let f1r3fly_api = F1r3flyApi::new(DEV_PRIVATE_KEY, &args.host, 40412)?;
+    let f1r3fly_api = F1r3flyApi::new_readonly(&args.host, 40412);
     let start_time = Instant::now();
 
     // Try detail view first (Rust node with PR #472+)
@@ -684,7 +682,7 @@ in {{
 
 /// Read data at a deploy ID from a specific block
 pub async fn get_data_command(args: &GetDataArgs) -> crate::error::Result<()> {
-    let f1r3fly_api = F1r3flyApi::new(&args.private_key, &args.host, args.port)?;
+    let f1r3fly_api = F1r3flyApi::new_readonly(&args.host, args.port);
 
     let pars = f1r3fly_api
         .get_data_at_deploy_id(&args.deploy_id, &args.block_hash)
@@ -721,7 +719,7 @@ pub async fn deploy_status_command(
     let sig_hex = args.sig.trim_start_matches("0x");
 
     // Reusing F1r3flyApi just for the HTTP method (port 0 is fine — never used here).
-    let api = F1r3flyApi::new(DEV_PRIVATE_KEY, &args.host, 0)?;
+    let api = F1r3flyApi::new_readonly(&args.host, 0);
     let start = Instant::now();
 
     let status = match api

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -330,11 +330,7 @@ pub async fn wallet_balance_command(
     println!(" Checking wallet balance for address: {}", args.address);
 
     // Use F1r3fly API with gRPC (like exploratory-deploy)
-    let f1r3fly_api = F1r3flyApi::new(
-        "5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657", // Bootstrap private key
-        &args.host,
-        args.port,
-    )?;
+    let f1r3fly_api = F1r3flyApi::new_readonly(&args.host, args.port);
 
     let rholang_query = format!(
         r#"new return, rl(`rho:registry:lookup`), systemVaultCh, vaultCh, balanceCh in {{
@@ -984,7 +980,7 @@ pub async fn show_main_chain_command(
     println!(" Depth: {} blocks", args.depth);
 
     // Initialize the F1r3fly API client
-    let f1r3fly_api = F1r3flyApi::new(&args.private_key, &args.host, args.port)?;
+    let f1r3fly_api = F1r3flyApi::new_readonly(&args.host, args.port);
 
     let start_time = Instant::now();
 
@@ -1035,11 +1031,7 @@ pub async fn validator_status_command(
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!(" Checking validator status for: {}", args.public_key);
 
-    let f1r3fly_api = F1r3flyApi::new(
-        "5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657", // Bootstrap private key
-        &args.host,
-        args.port,
-    )?;
+    let f1r3fly_api = F1r3flyApi::new_readonly(&args.host, args.port);
 
     let start_time = Instant::now();
 
@@ -1174,11 +1166,7 @@ pub async fn epoch_info_command(args: &PosQueryArgs) -> Result<(), Box<dyn std::
         args.host, args.port
     );
 
-    let f1r3fly_api = F1r3flyApi::new(
-        "5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657", // Bootstrap private key
-        &args.host,
-        args.port,
-    )?;
+    let f1r3fly_api = F1r3flyApi::new_readonly(&args.host, args.port);
 
     let start_time = Instant::now();
 
@@ -1440,11 +1428,7 @@ pub async fn network_consensus_command(
         args.host, args.port
     );
 
-    let f1r3fly_api = F1r3flyApi::new(
-        "5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657",
-        &args.host,
-        args.port,
-    )?;
+    let f1r3fly_api = F1r3flyApi::new_readonly(&args.host, args.port);
 
     let start_time = Instant::now();
 
@@ -1599,7 +1583,7 @@ pub async fn get_blocks_by_height_command(
     }
 
     // Initialize the F1r3fly API client
-    let f1r3fly_api = F1r3flyApi::new(&args.private_key, &args.host, args.port)?;
+    let f1r3fly_api = F1r3flyApi::new_readonly(&args.host, args.port);
 
     let start_time = Instant::now();
 

--- a/src/grpc/deploy.rs
+++ b/src/grpc/deploy.rs
@@ -254,11 +254,15 @@ impl<'a> F1r3flyApi<'a> {
         let serialized = projection.encode_to_vec();
         let digest = blake2b_256_hash(&serialized);
 
+        let signing_key = self
+            .signing_key
+            .as_ref()
+            .expect("build_deploy_msg requires a signing key");
         let secp = Secp256k1::new();
         let message = Secp256k1Message::from_digest(digest.into());
-        let signature = secp.sign_ecdsa(message, &self.signing_key);
+        let signature = secp.sign_ecdsa(message, signing_key);
         let sig_bytes = signature.serialize_der().to_vec();
-        let public_key = self.signing_key.public_key(&secp);
+        let public_key = signing_key.public_key(&secp);
         let pub_key_bytes = public_key.serialize_uncompressed().to_vec();
 
         DeployDataProto {

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -13,7 +13,7 @@ const TIP_FLOOR_UNSET: i64 = -1;
 
 /// Client for interacting with the F1r3fly node via gRPC and HTTP
 pub struct F1r3flyApi<'a> {
-    pub(crate) signing_key: SecretKey,
+    pub(crate) signing_key: Option<SecretKey>,
     pub(crate) node_host: &'a str,
     pub(crate) grpc_port: u16,
     pub(crate) tip_floor: Arc<AtomicI64>,
@@ -31,11 +31,22 @@ impl<'a> F1r3flyApi<'a> {
         })?;
         let secret_key = SecretKey::from_byte_array(key_array)?;
         Ok(F1r3flyApi {
-            signing_key: secret_key,
+            signing_key: Some(secret_key),
             node_host,
             grpc_port,
             tip_floor: Arc::new(AtomicI64::new(TIP_FLOOR_UNSET)),
         })
+    }
+
+    /// Construct a client for read-only operations (exploratory deploys and
+    /// HTTP reads). These paths never sign, so no key is required.
+    pub fn new_readonly(node_host: &'a str, grpc_port: u16) -> Self {
+        F1r3flyApi {
+            signing_key: None,
+            node_host,
+            grpc_port,
+            tip_floor: Arc::new(AtomicI64::new(TIP_FLOOR_UNSET)),
+        }
     }
 
     pub(crate) fn grpc_url(&self) -> String {


### PR DESCRIPTION
- remove hardcoded `DEV_PRIVATE_KEY` default; signing commands require `--private-key` or `FIREFLY_PRIVATE_KEY` env
 - read-only commands (wallet-balance, validator-status, epoch-info, network-consensus) use keyless `F1r3flyApi::new_readonly`

  fix of #24 issue